### PR TITLE
V1.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-archwizard",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "MIT",
   "description": "An angular 2 module containing a wizard component and its supporting components and directives",
   "homepage": "https://github.com/madoar/ng2-archwizard",

--- a/src/components/components/wizard-navigation-bar.component.horizontal.less
+++ b/src/components/components/wizard-navigation-bar.component.horizontal.less
@@ -363,6 +363,7 @@
 
     li.default,
     li.current,
+    li.optional,
     li.editing {
       pointer-events: none;
     }

--- a/src/components/components/wizard-navigation-bar.component.vertical.less
+++ b/src/components/components/wizard-navigation-bar.component.vertical.less
@@ -344,6 +344,7 @@
 
     li.default,
     li.current,
+    li.optional,
     li.editing {
       pointer-events: none;
     }


### PR DESCRIPTION
This PR introduces a bugfix in the horizontal and vertical css layouts for the navigation bar.
In v1.5.1 it is possible to click on optional step titles in the navigation bar, even if the optional step has not been completed yet, this should be fixed now.