### PR TITLE
Add an enableBackLinks directive, which enables a user to leave an entered completion step

### DIFF
--- a/src/components/components/wizard-completion-step.component.ts
+++ b/src/components/components/wizard-completion-step.component.ts
@@ -145,6 +145,7 @@ export class WizardCompletionStepComponent extends WizardStep {
    * @inheritDoc
    */
   exit(direction: MovingDirection): void {
-    // do nothing
+    this.wizard.completed = false;
+    this.stepExit.emit(direction);
   }
 }

--- a/src/components/directives/enable-back-links.directive.spec.ts
+++ b/src/components/directives/enable-back-links.directive.spec.ts
@@ -1,0 +1,164 @@
+/**
+ * Created by marc on 30.06.17.
+ */
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {ViewChild, Component} from '@angular/core';
+import {WizardComponent} from '../components/wizard.component';
+import {MovingDirection} from '../util/moving-direction.enum';
+import {By} from '@angular/platform-browser';
+import {WizardModule} from '../wizard.module';
+
+@Component({
+  selector: 'test-wizard',
+  template: `
+    <wizard>
+      <wizard-step title='Steptitle 1' (stepEnter)="enterInto($event, 1)" (stepExit)="exitFrom($event, 1)">
+        Step 1
+      </wizard-step>
+      <wizard-step title='Steptitle 2' [canExit]="isValid"
+                   optionalStep (stepEnter)="enterInto($event, 2)" (stepExit)="exitFrom($event, 2)">
+        Step 2
+      </wizard-step>
+      <wizard-completion-step enableBackLinks title='Completion steptitle 3' (stepEnter)="enterInto($event, 3)"
+                              (stepExit)="completionStepExit($event, 3)">
+        Step 3
+      </wizard-completion-step>
+    </wizard>
+  `
+})
+class WizardTestComponent {
+  @ViewChild(WizardComponent)
+  public wizard: WizardComponent;
+
+  public isValid: any = true;
+
+  public eventLog: Array<string> = new Array<string>();
+
+  public completionStepExit: (direction: MovingDirection, source: number) => void = this.exitFrom;
+
+  enterInto(direction: MovingDirection, destination: number): void {
+    this.eventLog.push(`enter ${MovingDirection[direction]} ${destination}`);
+  }
+
+  exitFrom(direction: MovingDirection, source: number): void {
+    this.eventLog.push(`exit ${MovingDirection[direction]} ${source}`);
+  }
+}
+
+describe('EnableBackLinksDirective', () => {
+  let wizardTest: WizardTestComponent;
+  let wizardTestFixture: ComponentFixture<WizardTestComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [WizardTestComponent],
+      imports: [WizardModule]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    wizardTestFixture = TestBed.createComponent(WizardTestComponent);
+    wizardTest = wizardTestFixture.componentInstance;
+    wizardTestFixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(wizardTest).toBeTruthy();
+    expect(wizardTestFixture.debugElement.queryAll(By.css('wizard-step')).length).toBe(2);
+    expect(wizardTestFixture.debugElement.queryAll(By.css('wizard-completion-step')).length).toBe(1);
+  });
+
+  it('should have correct step title', () => {
+    expect(wizardTest).toBeTruthy();
+    expect(wizardTest.wizard.getStepAtIndex(0).title).toBe('Steptitle 1');
+    expect(wizardTest.wizard.getStepAtIndex(1).title).toBe('Steptitle 2');
+    expect(wizardTest.wizard.getStepAtIndex(2).title).toBe('Completion steptitle 3');
+  });
+
+  it('should enter first step after initialisation', () => {
+    expect(wizardTest.eventLog).toEqual(['enter Forwards 1']);
+  });
+
+  it('should enter completion step after first step', () => {
+    expect(wizardTest.wizard.currentStepIndex).toBe(0);
+
+    wizardTest.wizard.goToNextStep();
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    expect(wizardTest.eventLog).toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 2']);
+
+    wizardTest.wizard.goToNextStep();
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.wizard.currentStepIndex).toBe(2);
+    expect(wizardTest.eventLog).toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 2',
+      'exit Forwards 2', 'enter Forwards 3']);
+  });
+
+  it('should enter completion step after jumping over second optional step', () => {
+    wizardTest.wizard.goToStep(2);
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.wizard.completed).toBe(true);
+    expect(wizardTest.eventLog).toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 3']);
+  });
+
+  it('should be able to leave the completion step', () => {
+    wizardTest.wizard.goToStep(2);
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.wizard.canGoToStep(0)).toBe(true);
+    expect(wizardTest.wizard.canGoToStep(1)).toBe(true);
+  });
+
+
+  it('should be able to leave the completion step in any direction', () => {
+    wizardTest.isValid = false;
+
+    wizardTest.wizard.goToStep(2);
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.wizard.currentStepIndex).toBe(2);
+    expect(wizardTest.wizard.currentStep.canExit).toBe(true);
+  });
+
+  it('should leave the completion step', () => {
+    wizardTest.isValid = false;
+
+    wizardTest.wizard.goToStep(2);
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.wizard.currentStepIndex).toBe(2);
+
+    wizardTest.wizard.goToPreviousStep();
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    expect(wizardTest.eventLog)
+      .toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 3', 'exit Backwards 3', 'enter Backwards 2']);
+  });
+
+  it('should work with changed stepExit value', () => {
+    wizardTest.isValid = false;
+    wizardTest.completionStepExit = (direction: MovingDirection, source: number) => {
+      wizardTest.eventLog.push(`changed exit ${MovingDirection[direction]} ${source}`);
+    };
+
+    expect(wizardTest.wizard.completed).toBe(false);
+
+    wizardTest.wizard.goToStep(2);
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.wizard.currentStepIndex).toBe(2);
+    expect(wizardTest.wizard.completed).toBe(true);
+
+    wizardTest.wizard.goToPreviousStep();
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    expect(wizardTest.eventLog)
+      .toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 3', 'changed exit Backwards 3', 'enter Backwards 2']);
+    expect(wizardTest.wizard.completed).toBe(false);
+  });
+});

--- a/src/components/directives/enable-back-links.directive.ts
+++ b/src/components/directives/enable-back-links.directive.ts
@@ -1,0 +1,53 @@
+import {Directive, EventEmitter, Host, OnInit, Output} from '@angular/core';
+import {WizardCompletionStepComponent} from '../components/wizard-completion-step.component';
+import {MovingDirection} from '../util/moving-direction.enum';
+
+/**
+ * The `enableBackLinks` directive can be used to allow the user to leave a [[WizardCompletionStepComponent]] after is has been entered.
+ *
+ * ### Syntax
+ *
+ * ```html
+ * <wizard-completion-step enableBackLinks (stepExit)="exit function">
+ *     ...
+ * </wizard-completion-step>
+ * ```
+ *
+ * ### Example
+ *
+ * ```html
+ * <wizard-completion-step title="Final step" enableBackLinks>
+ *     ...
+ * </wizard-completion-step>
+ * ```
+ *
+ * @author Marc Arndt
+ */
+@Directive({
+  selector: 'wizard-completion-step[enableBackLinks]'
+})
+export class EnableBackLinksDirective implements OnInit {
+  /**
+   * This EventEmitter is called when the step is exited.
+   * The bound method can be used to do cleanup work.
+   *
+   * @type {EventEmitter<MovingDirection>}
+   */
+  @Output()
+  public stepExit = new EventEmitter<MovingDirection>();
+
+  /**
+   * Constructor
+   *
+   * @param completionStep The wizard completion step, which should be exitable
+   */
+  constructor(@Host() private completionStep: WizardCompletionStepComponent) { }
+
+  /**
+   * Initialization work
+   */
+  ngOnInit(): void {
+    this.completionStep.canExit = true;
+    this.completionStep.stepExit = this.stepExit;
+  }
+}

--- a/src/components/directives/index.ts
+++ b/src/components/directives/index.ts
@@ -7,4 +7,5 @@ export {NextStepDirective} from './next-step.directive';
 export {PreviousStepDirective} from './previous-step.directive';
 export {OptionalStepDirective} from './optional-step.directive';
 export {WizardStepTitleDirective} from './wizard-step-title.directive';
+export {EnableBackLinksDirective} from './enable-back-links.directive';
 

--- a/src/components/directives/optional-step.directive.ts
+++ b/src/components/directives/optional-step.directive.ts
@@ -3,8 +3,7 @@ import {WizardStep} from '../util/wizard-step.interface';
 
 /**
  * The `optionalStep` directive can be used to define an optional `wizard-step`.
- * An optional `wizard-step` is a [[WizardStepComponent]] that doesn't need to be completed to transition to later wizard steps.
- * It's important to note, that this directive can only be used on a [[WizardStepComponent]] and not a [[WizardCompletionStepComponent]]
+ * An optional `wizard-step` is a [[WizardStep]] that doesn't need to be completed to transition to later wizard steps.
  *
  * ### Syntax
  *
@@ -31,7 +30,7 @@ export class OptionalStepDirective implements OnInit {
   /**
    * Constructor
    *
-   * @param wizardStep The wizard, which contains this [[OptionalStepDirective]]
+   * @param wizardStep The wizard step, which contains this [[OptionalStepDirective]]
    */
   constructor(@Host() private wizardStep: WizardStep) { }
 

--- a/src/components/wizard.module.ts
+++ b/src/components/wizard.module.ts
@@ -11,6 +11,7 @@ import {PreviousStepDirective} from './directives/previous-step.directive';
 import {OptionalStepDirective} from './directives/optional-step.directive';
 import {GoToStepDirective} from './directives/go-to-step.directive';
 import {WizardStepTitleDirective} from './directives/wizard-step-title.directive';
+import {EnableBackLinksDirective} from './directives/enable-back-links.directive';
 
 /**
  * The module defining all the content inside `ng2-archwizard`
@@ -27,7 +28,8 @@ import {WizardStepTitleDirective} from './directives/wizard-step-title.directive
     NextStepDirective,
     PreviousStepDirective,
     OptionalStepDirective,
-    WizardStepTitleDirective
+    WizardStepTitleDirective,
+    EnableBackLinksDirective
   ],
   imports: [
     CommonModule
@@ -41,7 +43,8 @@ import {WizardStepTitleDirective} from './directives/wizard-step-title.directive
     NextStepDirective,
     PreviousStepDirective,
     OptionalStepDirective,
-    WizardStepTitleDirective
+    WizardStepTitleDirective,
+    EnableBackLinksDirective
   ]
 })
 export class WizardModule {


### PR DESCRIPTION
This PR targets the feature request in #9, where a way is required to make an entered `WizardCompletionStepComponent` exitable.
This has been realized via a new `enableBackLinks` directive that can be added to a `WizardCompletionStepComponent`. This enables a user to leave an entered `WizardCompletionStepComponent` again.