### PR TITLE
Add two new directives to define a wizard and wizard completion step

### DIFF
--- a/src/components/components/wizard-completion-step.component.ts
+++ b/src/components/components/wizard-completion-step.component.ts
@@ -80,27 +80,18 @@ export class WizardCompletionStepComponent extends WizardCompletionStep {
   public navigationSymbolFontFamily: string;
 
   /**
-   * This EventEmitter is called when the step is entered.
-   * The bound method should be used to do initialization work.
-   *
-   * @type {EventEmitter<MovingDirection>}
+   * @inheritDoc
    */
   @Output()
   public stepEnter = new EventEmitter<MovingDirection>();
 
   /**
-   * This EventEmitter is called when the step is exited.
-   * The bound method can be used to do cleanup work.
-   *
-   * @type {EventEmitter<MovingDirection>}
+   * @inheritDoc
    */
   public stepExit = new EventEmitter<MovingDirection>();
 
   /**
-   * Returns if this wizard step should be visible to the user.
-   * If the step should be visible to the user false is returned, otherwise true
-   *
-   * @returns {boolean}
+   * @inheritDoc
    */
   @HostBinding('hidden')
   public get hidden(): boolean {

--- a/src/components/components/wizard-step.component.ts
+++ b/src/components/components/wizard-step.component.ts
@@ -91,28 +91,19 @@ export class WizardStepComponent extends WizardStep {
   public canExit: ((direction: MovingDirection) => boolean) | boolean = true;
 
   /**
-   * This EventEmitter is called when the step is entered.
-   * The bound method should be used to do initialization work.
-   *
-   * @type {EventEmitter<MovingDirection>}
+   * @inheritDoc
    */
   @Output()
   public stepEnter = new EventEmitter<MovingDirection>();
 
   /**
-   * This EventEmitter is called when the step is exited.
-   * The bound method can be used to do cleanup work.
-   *
-   * @type {EventEmitter<MovingDirection>}
+   * @inheritDoc
    */
   @Output()
   public stepExit = new EventEmitter<MovingDirection>();
 
   /**
-   * Returns if this wizard step should be visible to the user.
-   * If the step should be visible to the user false is returned, otherwise true
-   *
-   * @returns {boolean}
+   * @inheritDoc
    */
   @HostBinding('hidden')
   public get hidden(): boolean {

--- a/src/components/directives/enable-back-links.directive.ts
+++ b/src/components/directives/enable-back-links.directive.ts
@@ -1,9 +1,9 @@
 import {Directive, EventEmitter, Host, OnInit, Output} from '@angular/core';
-import {WizardCompletionStepComponent} from '../components/wizard-completion-step.component';
 import {MovingDirection} from '../util/moving-direction.enum';
+import {WizardCompletionStep} from '../util/wizard-completion-step.inferface';
 
 /**
- * The `enableBackLinks` directive can be used to allow the user to leave a [[WizardCompletionStepComponent]] after is has been entered.
+ * The `enableBackLinks` directive can be used to allow the user to leave a [[WizardCompletionStep]] after is has been entered.
  *
  * ### Syntax
  *
@@ -24,7 +24,7 @@ import {MovingDirection} from '../util/moving-direction.enum';
  * @author Marc Arndt
  */
 @Directive({
-  selector: 'wizard-completion-step[enableBackLinks]'
+  selector: '[enableBackLinks]'
 })
 export class EnableBackLinksDirective implements OnInit {
   /**
@@ -41,7 +41,7 @@ export class EnableBackLinksDirective implements OnInit {
    *
    * @param completionStep The wizard completion step, which should be exitable
    */
-  constructor(@Host() private completionStep: WizardCompletionStepComponent) { }
+  constructor(@Host() private completionStep: WizardCompletionStep) { }
 
   /**
    * Initialization work

--- a/src/components/directives/wizard-completion-step.directive.spec.ts
+++ b/src/components/directives/wizard-completion-step.directive.spec.ts
@@ -2,21 +2,27 @@
  * Created by marc on 20.05.17.
  */
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {WizardCompletionStepComponent} from './wizard-completion-step.component';
 import {ViewChild, Component} from '@angular/core';
-import {WizardComponent} from './wizard.component';
+import {WizardComponent} from '../components/wizard.component';
 import {MovingDirection} from '../util/moving-direction.enum';
 import {By} from '@angular/platform-browser';
 import {WizardModule} from '../wizard.module';
+import {WizardCompletionStepDirective} from './wizard-completion-step.directive';
 
 @Component({
   selector: 'test-wizard',
   template: `
     <wizard>
-      <wizard-step title='Steptitle 1' (stepEnter)="enterInto($event, 1)" (stepExit)="exitFrom($event, 1)">Step 1</wizard-step>
+      <wizard-step title='Steptitle 1' (stepEnter)="enterInto($event, 1)" (stepExit)="exitFrom($event, 1)">
+        Step 1
+      </wizard-step>
       <wizard-step title='Steptitle 2' [canExit]="isValid"
-                   optionalStep (stepEnter)="enterInto($event, 2)" (stepExit)="exitFrom($event, 2)">Step 2</wizard-step>
-      <wizard-completion-step title='Completion steptitle 3' (stepEnter)="enterInto($event, 3)">Step 3</wizard-completion-step>
+                   optionalStep (stepEnter)="enterInto($event, 2)" (stepExit)="exitFrom($event, 2)">
+        Step 2
+      </wizard-step>
+      <div wizardCompletionStep title='Completion steptitle 3' (stepEnter)="enterInto($event, 3)">
+        Step 3
+      </div>
     </wizard>
   `
 })
@@ -37,7 +43,7 @@ class WizardTestComponent {
   }
 }
 
-describe('WizardCompletionStepComponent', () => {
+describe('WizardCompletionStepDirective', () => {
   let wizardTest: WizardTestComponent;
   let wizardTestFixture: ComponentFixture<WizardTestComponent>;
 
@@ -57,7 +63,7 @@ describe('WizardCompletionStepComponent', () => {
   it('should create', () => {
     expect(wizardTest).toBeTruthy();
     expect(wizardTestFixture.debugElement.queryAll(By.css('wizard-step')).length).toBe(2);
-    expect(wizardTestFixture.debugElement.queryAll(By.css('wizard-completion-step')).length).toBe(1);
+    expect(wizardTestFixture.debugElement.queryAll(By.directive(WizardCompletionStepDirective)).length).toBe(1);
   });
 
   it('should have correct step title', () => {

--- a/src/components/directives/wizard-completion-step.directive.ts
+++ b/src/components/directives/wizard-completion-step.directive.ts
@@ -1,60 +1,54 @@
-/**
- * Created by marc on 20.05.17.
- */
-
-import {Component, ContentChild, EventEmitter, forwardRef, HostBinding, Inject, Input, Output} from '@angular/core';
+import {ContentChild, Directive, EventEmitter, forwardRef, HostBinding, Inject, Input, Output} from '@angular/core';
 import {MovingDirection} from '../util/moving-direction.enum';
-import {WizardComponent} from './wizard.component';
+import {WizardComponent} from '../components/wizard.component';
 import {WizardStep} from '../util/wizard-step.interface';
-import {WizardStepTitleDirective} from '../directives/wizard-step-title.directive';
+import {WizardStepTitleDirective} from './wizard-step-title.directive';
 import {WizardCompletionStep} from '../util/wizard-completion-step.inferface';
 
 /**
- * The `wizard-completion-step` component can be used to define a completion/success step at the end of your wizard
- * After a `wizard-completion-step` has been entered, it has the characteristic that the user is blocked from
+ * The `wizardCompletionStep` directive can be used to define a completion/success step at the end of your wizard
+ * After a [[WizardCompletionStep]] has been entered, it has the characteristic that the user is blocked from
  * leaving it again to a previous step.
- * In addition entering a `wizard-completion-step` automatically sets the `wizard` amd all steps inside the `wizard`
+ * In addition entering a [[WizardCompletionStep]] automatically sets the `wizard` amd all steps inside the `wizard`
  * as completed.
  *
  * ### Syntax
  *
  * ```html
- * <wizard-completion-step [title]="title of the wizard step" [navigationSymbol]="navigation symbol"
+ * <div wizardCompletionStep [title]="title of the wizard step" [navigationSymbol]="navigation symbol"
  *    [navigationSymbolFontFamily]="navigation symbol font family"
  *    (stepEnter)="event emitter to be called when the wizard step is entered"
  *    (stepExit)="event emitter to be called when the wizard step is exited">
  *    ...
- * </wizard-completion-step>
+ * </div>
  * ```
  *
  * ### Example
  *
  * ```html
- * <wizard-completion-step title="Step 1" navigationSymbol="1">
+ * <div wizardCompletionStep title="Step 1" navigationSymbol="1">
  *    ...
- * </wizard-completion-step>
+ * </div>
  * ```
  *
  * With a navigation symbol from the `font-awesome` font:
  *
  * ```html
- * <wizard-completion-step title="Step 1" navigationSymbol="&#xf1ba;" navigationSymbolFontFamily="FontAwesome">
+ * <div wizardCompletionStep title="Step 1" navigationSymbol="&#xf1ba;" navigationSymbolFontFamily="FontAwesome">
  *    ...
- * </wizard-completion-step>
+ * </div>
  * ```
  *
  * @author Marc Arndt
  */
-@Component({
-  selector: 'wizard-completion-step',
-  templateUrl: 'wizard-completion-step.component.html',
-  styleUrls: ['wizard-completion-step.component.css'],
+@Directive({
+  selector: '[wizardCompletionStep]',
   providers: [
-    { provide: WizardStep, useExisting: forwardRef(() => WizardCompletionStepComponent) },
-    { provide: WizardCompletionStep, useExisting: forwardRef(() => WizardCompletionStepComponent) }
+    { provide: WizardStep, useExisting: forwardRef(() => WizardCompletionStepDirective) },
+    { provide: WizardCompletionStep, useExisting: forwardRef(() => WizardCompletionStepDirective) }
   ]
 })
-export class WizardCompletionStepComponent extends WizardCompletionStep {
+export class WizardCompletionStepDirective extends WizardCompletionStep {
   /**
    * @inheritDoc
    */

--- a/src/components/directives/wizard-completion-step.directive.ts
+++ b/src/components/directives/wizard-completion-step.directive.ts
@@ -74,27 +74,18 @@ export class WizardCompletionStepDirective extends WizardCompletionStep {
   public navigationSymbolFontFamily: string;
 
   /**
-   * This EventEmitter is called when the step is entered.
-   * The bound method should be used to do initialization work.
-   *
-   * @type {EventEmitter<MovingDirection>}
+   * @inheritDoc
    */
   @Output()
   public stepEnter = new EventEmitter<MovingDirection>();
 
   /**
-   * This EventEmitter is called when the step is exited.
-   * The bound method can be used to do cleanup work.
-   *
-   * @type {EventEmitter<MovingDirection>}
+   * @inheritDoc
    */
   public stepExit = new EventEmitter<MovingDirection>();
 
   /**
-   * Returns if this wizard step should be visible to the user.
-   * If the step should be visible to the user false is returned, otherwise true
-   *
-   * @returns {boolean}
+   * @inheritDoc
    */
   @HostBinding('hidden')
   public get hidden(): boolean {

--- a/src/components/directives/wizard-step.directive.spec.ts
+++ b/src/components/directives/wizard-step.directive.spec.ts
@@ -1,0 +1,283 @@
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {ViewChild, Component, Host, EventEmitter, forwardRef} from '@angular/core';
+import {WizardComponent} from '../components/wizard.component';
+import {MovingDirection} from '../util/moving-direction.enum';
+import {By} from '@angular/platform-browser';
+import {WizardModule} from '../wizard.module';
+import {WizardStepDirective} from './wizard-step.directive';
+
+@Component({
+  selector: 'test-wizard',
+  template: `
+    <wizard>
+      <div wizardStep title='Steptitle 1' (stepEnter)="enterInto($event, 1)" (stepExit)="exitFrom($event, 1)">
+        Step 1
+      </div>
+      <test-wizard-step wizardStep optionalStep>
+        Step 2
+      </test-wizard-step>
+      <div wizardStep title='Steptitle 3' (stepEnter)="enterInto($event, 3)" (stepExit)="exitFrom($event, 3)">
+        Step 3
+      </div>
+    </wizard>
+  `
+})
+class WizardTestComponent {
+  @ViewChild(WizardComponent)
+  public wizard: WizardComponent;
+
+  @ViewChild(forwardRef(() => WizardStepTestComponent))
+  public wizardStepTestComponent;
+
+  public eventLog: Array<string> = new Array<string>();
+
+  enterInto(direction: MovingDirection, destination: number): void {
+    this.eventLog.push(`enter ${MovingDirection[direction]} ${destination}`);
+  }
+
+  exitFrom(direction: MovingDirection, source: number): void {
+    this.eventLog.push(`exit ${MovingDirection[direction]} ${source}`);
+  }
+}
+
+@Component({
+  selector: 'test-wizard-step',
+  template: `
+    Step 2
+  `
+})
+class WizardStepTestComponent {
+  public set isValid(valid: any) {
+    this.wizardStep.canExit = valid;
+  }
+
+  constructor(@Host() private wizardStep: WizardStepDirective, wizard: WizardTestComponent) {
+    wizardStep.title = 'Steptitle 2';
+    wizardStep.stepEnter.emit = direction => wizard.enterInto(direction, 2);
+    wizardStep.stepExit.emit = direction => wizard.exitFrom(direction, 2);
+  }
+}
+
+
+describe('WizardStepDirective', () => {
+  let wizardTest: WizardTestComponent;
+  let wizardTestFixture: ComponentFixture<WizardTestComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [WizardTestComponent, WizardStepTestComponent],
+      imports: [WizardModule]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    wizardTestFixture = TestBed.createComponent(WizardTestComponent);
+    wizardTest = wizardTestFixture.componentInstance;
+    wizardTestFixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(wizardTest).toBeTruthy();
+    expect(wizardTestFixture.debugElement.queryAll(By.directive(WizardStepDirective)).length).toBe(3);
+  });
+
+  it('should have correct step title', () => {
+    expect(wizardTest).toBeTruthy();
+    expect(wizardTest.wizard.getStepAtIndex(0).title).toBe('Steptitle 1');
+    expect(wizardTest.wizard.getStepAtIndex(1).title).toBe('Steptitle 2');
+    expect(wizardTest.wizard.getStepAtIndex(2).title).toBe('Steptitle 3');
+  });
+
+  it('should enter first step after initialisation', () => {
+    expect(wizardTest.eventLog).toEqual(['enter Forwards 1']);
+  });
+
+  it('should enter second step after first step', () => {
+    wizardTest.wizard.goToNextStep();
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.eventLog).toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 2']);
+  });
+
+  it('should enter first step after exiting second step', () => {
+    wizardTest.wizard.goToNextStep();
+    wizardTest.wizard.goToPreviousStep();
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.eventLog)
+      .toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 2', 'exit Backwards 2', 'enter Backwards 1']);
+  });
+
+  it('should enter third step after jumping over second optional step', () => {
+    wizardTest.wizard.goToStep(2);
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.eventLog).toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 3']);
+  });
+
+  it('should enter first step after jumping over second optional step two times', () => {
+    wizardTest.wizard.goToStep(2);
+    wizardTest.wizard.goToStep(0);
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.eventLog)
+      .toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 3', 'exit Backwards 3', 'enter Backwards 1']);
+  });
+
+  it('should enter second step after jumping over second optional step and the going back once', () => {
+    wizardTest.wizard.goToStep(2);
+    wizardTest.wizard.goToPreviousStep();
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.eventLog)
+      .toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 3', 'exit Backwards 3', 'enter Backwards 2']);
+  });
+
+  it('should stay at first step correctly', () => {
+    wizardTest.wizard.goToStep(0);
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.eventLog).toEqual(['enter Forwards 1', 'exit Stay 1', 'enter Stay 1']);
+  });
+
+  it('should not be able to leave the second step in any direction', () => {
+    wizardTest.wizardStepTestComponent.isValid = false;
+
+    wizardTest.wizard.goToNextStep();
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    expect(wizardTest.wizard.currentStep.canExit).toBe(false);
+  });
+
+  it('should not be able to leave the second step in forwards direction', () => {
+    wizardTest.wizardStepTestComponent.isValid = direction => direction !== MovingDirection.Forwards;
+
+    wizardTest.wizard.goToNextStep();
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    expect(wizardTest.wizard.canExitStep(wizardTest.wizard.currentStep, MovingDirection.Forwards)).toBe(false);
+    expect(wizardTest.wizard.canExitStep(wizardTest.wizard.currentStep, MovingDirection.Backwards)).toBe(true);
+    expect(wizardTest.wizard.canExitStep(wizardTest.wizard.currentStep, MovingDirection.Stay)).toBe(true);
+  });
+
+  it('should not be able to leave the second step in backwards direction', () => {
+    wizardTest.wizardStepTestComponent.isValid = direction => direction !== MovingDirection.Backwards;
+
+    wizardTest.wizard.goToNextStep();
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    expect(wizardTest.wizard.canExitStep(wizardTest.wizard.currentStep, MovingDirection.Forwards)).toBe(true);
+    expect(wizardTest.wizard.canExitStep(wizardTest.wizard.currentStep, MovingDirection.Backwards)).toBe(false);
+    expect(wizardTest.wizard.canExitStep(wizardTest.wizard.currentStep, MovingDirection.Stay)).toBe(true);
+  });
+
+  it('should throw error when method "canExit" is malformed', () => {
+    wizardTest.wizardStepTestComponent.isValid = 'String';
+
+    wizardTest.wizard.goToNextStep();
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    expect(() => wizardTest.wizard.canExitStep(wizardTest.wizard.currentStep, MovingDirection.Forwards))
+      .toThrow(new Error(`Input value 'String' is neither a boolean nor a function`));
+  });
+
+  it('should not leave the second step in forward direction if it can\'t be exited', () => {
+    wizardTest.wizardStepTestComponent.isValid = false;
+
+    wizardTest.wizard.goToNextStep();
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+
+    wizardTest.wizard.goToNextStep();
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    expect(wizardTest.eventLog)
+      .toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 2', 'exit Stay 2', 'enter Stay 2']);
+  });
+
+  it('should not leave the second step in backward direction if it can\'t be exited', () => {
+    wizardTest.wizardStepTestComponent.isValid = false;
+
+    wizardTest.wizard.goToNextStep();
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+
+    wizardTest.wizard.goToPreviousStep();
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    expect(wizardTest.eventLog)
+      .toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 2', 'exit Stay 2', 'enter Stay 2']);
+  });
+
+  it('should not leave the second step in forward direction if it can\'t be exited in this direction', () => {
+    wizardTest.wizardStepTestComponent.isValid = direction => direction === MovingDirection.Backwards;
+
+    wizardTest.wizard.goToNextStep();
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+
+    wizardTest.wizard.goToNextStep();
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    expect(wizardTest.eventLog)
+      .toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 2', 'exit Stay 2', 'enter Stay 2']);
+  });
+
+  it('should not leave the second step in backward direction if it can\'t be exited in this direction', () => {
+    wizardTest.wizardStepTestComponent.isValid = direction => direction === MovingDirection.Forwards;
+
+    wizardTest.wizard.goToNextStep();
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+
+    wizardTest.wizard.goToPreviousStep();
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    expect(wizardTest.eventLog)
+      .toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 2', 'exit Stay 2', 'enter Stay 2']);
+  });
+
+  it('should leave the second step in forward direction if it can be exited in this direction', () => {
+    wizardTest.wizardStepTestComponent.isValid = direction => direction === MovingDirection.Forwards;
+
+    wizardTest.wizard.goToNextStep();
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+
+    wizardTest.wizard.goToNextStep();
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.wizard.currentStepIndex).toBe(2);
+    expect(wizardTest.eventLog)
+      .toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 2', 'exit Forwards 2', 'enter Forwards 3']);
+  });
+
+  it('should leave the second step in backward direction if it can be exited in this direction', () => {
+    wizardTest.wizardStepTestComponent.isValid = direction => direction === MovingDirection.Backwards;
+
+    wizardTest.wizard.goToNextStep();
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+
+    wizardTest.wizard.goToPreviousStep();
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.wizard.currentStepIndex).toBe(0);
+    expect(wizardTest.eventLog)
+      .toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 2', 'exit Backwards 2', 'enter Backwards 1']);
+  });
+});

--- a/src/components/directives/wizard-step.directive.ts
+++ b/src/components/directives/wizard-step.directive.ts
@@ -1,0 +1,155 @@
+import {ContentChild, Directive, EventEmitter, forwardRef, HostBinding, Input, Output} from '@angular/core';
+import {MovingDirection} from '../util/moving-direction.enum';
+import {WizardStep} from '../util/wizard-step.interface';
+import {WizardStepTitleDirective} from './wizard-step-title.directive';
+
+/**
+ * The `wizardStep` directive can be used to define a normal step inside a wizard.
+ *
+ * ### Syntax
+ *
+ * With `title` input:
+ *
+ * ```html
+ * <div wizardStep [title]="step title" [navigationSymbol]="symbol" [navigationSymbolFontFamily]="font-family"
+ *    [canExit]="deciding function" (stepEnter)="enter function" (stepExit)="exit function">
+ *    ...
+ * </div>
+ * ```
+ *
+ * With `wizardStepTitle` directive:
+ *
+ * ```html
+ * <div wizardStep [navigationSymbol]="symbol" [navigationSymbolFontFamily]="font-family"
+ *    [canExit]="deciding function" (stepEnter)="enter function" (stepExit)="exit function">
+ *    <ng-template wizardStepTitle>
+ *        step title
+ *    </ng-template>
+ *    ...
+ * </div>
+ * ```
+ *
+ * ### Example
+ *
+ * With `title` input:
+ *
+ * ```html
+ * <div wizardStep title="Address information" navigationSymbol="&#xf1ba;" navigationSymbolFontFamily="FontAwesome">
+ *    ...
+ * </div>
+ * ```
+ *
+ * With `wizardStepTitle` directive:
+ *
+ * ```html
+ * <div wizardStep navigationSymbol="&#xf1ba;" navigationSymbolFontFamily="FontAwesome">
+ *    <ng-template wizardStepTitle>
+ *        Address information
+ *    </ng-template>
+ * </div>
+ * ```
+ *
+ * @author Marc Arndt
+ */
+@Directive({
+  selector: '[wizardStep]',
+  providers: [
+    { provide: WizardStep, useExisting: forwardRef(() => WizardStepDirective) }
+  ]
+})
+export class WizardStepDirective extends WizardStep {
+  /**
+   * @inheritDoc
+   */
+  @ContentChild(WizardStepTitleDirective)
+  public titleTemplate: WizardStepTitleDirective;
+
+  /**
+   * @inheritDoc
+   */
+  @Input()
+  public title: string;
+
+  /**
+   * @inheritDoc
+   */
+  @Input()
+  public navigationSymbol = '';
+
+  /**
+   * @inheritDoc
+   */
+  @Input()
+  public navigationSymbolFontFamily: string;
+
+  /**
+   * @inheritDoc
+   */
+  @Input()
+  public canExit: ((direction: MovingDirection) => boolean) | boolean = true;
+
+  /**
+   * This EventEmitter is called when the step is entered.
+   * The bound method should be used to do initialization work.
+   *
+   * @type {EventEmitter<MovingDirection>}
+   */
+  @Output()
+  public stepEnter = new EventEmitter<MovingDirection>();
+
+  /**
+   * This EventEmitter is called when the step is exited.
+   * The bound method can be used to do cleanup work.
+   *
+   * @type {EventEmitter<MovingDirection>}
+   */
+  @Output()
+  public stepExit = new EventEmitter<MovingDirection>();
+
+  /**
+   * Returns if this wizard step should be visible to the user.
+   * If the step should be visible to the user false is returned, otherwise true
+   *
+   * @returns {boolean}
+   */
+  @HostBinding('hidden')
+  public get hidden(): boolean {
+    return !this.selected;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public completed = false;
+
+  /**
+   * @inheritDoc
+   */
+  public selected = false;
+
+  /**
+   * @inheritDoc
+   */
+  public optional = false;
+
+  /**
+   * Constructor
+   */
+  constructor() {
+    super();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  enter(direction: MovingDirection): void {
+    this.stepEnter.emit(direction);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  exit(direction: MovingDirection): void {
+    this.stepExit.emit(direction);
+  }
+}

--- a/src/components/directives/wizard-step.directive.ts
+++ b/src/components/directives/wizard-step.directive.ts
@@ -89,28 +89,19 @@ export class WizardStepDirective extends WizardStep {
   public canExit: ((direction: MovingDirection) => boolean) | boolean = true;
 
   /**
-   * This EventEmitter is called when the step is entered.
-   * The bound method should be used to do initialization work.
-   *
-   * @type {EventEmitter<MovingDirection>}
+   * @inheritDoc
    */
   @Output()
   public stepEnter = new EventEmitter<MovingDirection>();
 
   /**
-   * This EventEmitter is called when the step is exited.
-   * The bound method can be used to do cleanup work.
-   *
-   * @type {EventEmitter<MovingDirection>}
+   * @inheritDoc
    */
   @Output()
   public stepExit = new EventEmitter<MovingDirection>();
 
   /**
-   * Returns if this wizard step should be visible to the user.
-   * If the step should be visible to the user false is returned, otherwise true
-   *
-   * @returns {boolean}
+   * @inheritDoc
    */
   @HostBinding('hidden')
   public get hidden(): boolean {

--- a/src/components/util/wizard-completion-step.inferface.ts
+++ b/src/components/util/wizard-completion-step.inferface.ts
@@ -2,9 +2,15 @@ import {WizardStep} from './wizard-step.interface';
 import {EventEmitter} from '@angular/core';
 import {MovingDirection} from './moving-direction.enum';
 
+/**
+ * Basic functionality every wizard completion step needs to provide
+ *
+ * @author Marc Arndt
+ */
 export abstract class WizardCompletionStep extends WizardStep {
-  public stepExit: EventEmitter<MovingDirection>;
-
+  /**
+   * Constructor
+   */
   constructor() {
     super();
   }

--- a/src/components/util/wizard-completion-step.inferface.ts
+++ b/src/components/util/wizard-completion-step.inferface.ts
@@ -1,0 +1,11 @@
+import {WizardStep} from './wizard-step.interface';
+import {EventEmitter} from '@angular/core';
+import {MovingDirection} from './moving-direction.enum';
+
+export abstract class WizardCompletionStep extends WizardStep {
+  public stepExit: EventEmitter<MovingDirection>;
+
+  constructor() {
+    super();
+  }
+}

--- a/src/components/util/wizard-completion-step.inferface.ts
+++ b/src/components/util/wizard-completion-step.inferface.ts
@@ -1,6 +1,4 @@
 import {WizardStep} from './wizard-step.interface';
-import {EventEmitter} from '@angular/core';
-import {MovingDirection} from './moving-direction.enum';
 
 /**
  * Basic functionality every wizard completion step needs to provide

--- a/src/components/util/wizard-step.interface.spec.ts
+++ b/src/components/util/wizard-step.interface.spec.ts
@@ -8,6 +8,8 @@ import {WizardStepComponent} from '../components/wizard-step.component';
 import {WizardCompletionStepComponent} from '../components/wizard-completion-step.component';
 import {WizardModule} from '../wizard.module';
 import {WizardStep} from './wizard-step.interface';
+import {WizardCompletionStepDirective} from '../directives/wizard-completion-step.directive';
+import {WizardStepDirective} from '../directives/wizard-step.directive';
 
 @Component({
   selector: 'test-wizard',
@@ -25,9 +27,15 @@ import {WizardStep} from './wizard-step.interface';
         </ng-template>
         Step 3
       </wizard-step>
-      <wizard-completion-step #step4 title='Steptitle 4'>
+      <div wizardStep #step4 title='Steptitle 4'>
         Step 4
+      </div>
+      <wizard-completion-step #step5 title='Steptitle 5'>
+        Step 5
       </wizard-completion-step>
+      <div wizardCompletionStep #step6 title='Steptitle 6'>
+        Step 6
+      </div>
     </wizard>
   `
 })
@@ -44,8 +52,14 @@ class WizardTestComponent {
   @ViewChild('step3')
   public step3: WizardStepComponent;
 
-  @ViewChild('step4')
-  public step4: WizardCompletionStepComponent;
+  @ViewChild('step4', {read: WizardStepDirective})
+  public step4: WizardStepDirective;
+
+  @ViewChild('step5')
+  public step5: WizardCompletionStepComponent;
+
+  @ViewChild('step6', {read: WizardCompletionStepDirective})
+  public step6: WizardCompletionStepDirective;
 }
 
 describe('WizardStep', () => {
@@ -70,16 +84,22 @@ describe('WizardStep', () => {
     expect(wizardTest.step2).toBeDefined();
     expect(wizardTest.step3).toBeDefined();
     expect(wizardTest.step4).toBeDefined();
+    expect(wizardTest.step5).toBeDefined();
+    expect(wizardTest.step6).toBeDefined();
+
+    expect(wizardTest.wizard.wizardSteps.length).toBe(6);
   });
 
-  it('should fulfill isStepWizard', () => {
+  it('should be a WizardStep', () => {
     expect(wizardTest.step1 instanceof WizardStep).toBe(true, 'Step 1 couldn\'t be identified as a WizardStep');
     expect(wizardTest.step2 instanceof WizardStep).toBe(true, 'Step 2 couldn\'t be identified as a WizardStep');
     expect(wizardTest.step3 instanceof WizardStep).toBe(true, 'Step 3 couldn\'t be identified as a WizardStep');
     expect(wizardTest.step4 instanceof WizardStep).toBe(true, 'Step 4 couldn\'t be identified as a WizardStep');
+    expect(wizardTest.step5 instanceof WizardStep).toBe(true, 'Step 5 couldn\'t be identified as a WizardStep');
+    expect(wizardTest.step6 instanceof WizardStep).toBe(true, 'Step 6 couldn\'t be identified as a WizardStep');
   });
 
-  it('should not fulfill isStepWizard', () => {
+  it('should not be a WizardStep', () => {
     expect({stepOffset: 1} instanceof WizardStep).toBe(false);
     expect({title: 'Test title'} instanceof WizardStep).toBe(false);
   });

--- a/src/components/util/wizard-step.interface.ts
+++ b/src/components/util/wizard-step.interface.ts
@@ -1,6 +1,6 @@
 import {MovingDirection} from './moving-direction.enum';
 import {WizardStepTitleDirective} from '../directives/wizard-step-title.directive';
-import {EventEmitter} from "@angular/core";
+import {EventEmitter} from '@angular/core';
 
 /**
  * Basic functionality every type of wizard step needs to provide

--- a/src/components/util/wizard-step.interface.ts
+++ b/src/components/util/wizard-step.interface.ts
@@ -1,5 +1,6 @@
 import {MovingDirection} from './moving-direction.enum';
 import {WizardStepTitleDirective} from '../directives/wizard-step-title.directive';
+import {EventEmitter} from "@angular/core";
 
 /**
  * Basic functionality every type of wizard step needs to provide
@@ -51,6 +52,30 @@ export abstract class WizardStep {
    * A function, taking a [[MovingDirection]], or boolean returning true, if the step can be exited and false otherwise.
    */
   canExit: ((direction: MovingDirection) => boolean) | boolean;
+
+  /**
+   * This EventEmitter is called when the step is entered.
+   * The bound method should be used to do initialization work.
+   *
+   * @type {EventEmitter<MovingDirection>}
+   */
+  public stepEnter: EventEmitter<MovingDirection>;
+
+  /**
+   * This EventEmitter is called when the step is exited.
+   * The bound method can be used to do cleanup work.
+   *
+   * @type {EventEmitter<MovingDirection>}
+   */
+  public stepExit: EventEmitter<MovingDirection>;
+
+  /**
+   * Returns if this wizard step should be visible to the user.
+   * If the step should be visible to the user false is returned, otherwise true
+   *
+   * @returns {boolean}
+   */
+  abstract get hidden(): boolean;
 
   /**
    * A function called when the step is entered

--- a/src/components/util/wizard-step.interface.ts
+++ b/src/components/util/wizard-step.interface.ts
@@ -6,7 +6,6 @@ import {WizardStepTitleDirective} from '../directives/wizard-step-title.directiv
  *
  * @author Marc Arndt
  */
-/* istanbul ignore next */
 export abstract class WizardStep {
   /**
    * A title property, which contains the title of the step.

--- a/src/components/wizard.module.ts
+++ b/src/components/wizard.module.ts
@@ -12,6 +12,8 @@ import {OptionalStepDirective} from './directives/optional-step.directive';
 import {GoToStepDirective} from './directives/go-to-step.directive';
 import {WizardStepTitleDirective} from './directives/wizard-step-title.directive';
 import {EnableBackLinksDirective} from './directives/enable-back-links.directive';
+import {WizardStepDirective} from './directives/wizard-step.directive';
+import {WizardCompletionStepDirective} from './directives/wizard-completion-step.directive';
 
 /**
  * The module defining all the content inside `ng2-archwizard`
@@ -29,7 +31,9 @@ import {EnableBackLinksDirective} from './directives/enable-back-links.directive
     PreviousStepDirective,
     OptionalStepDirective,
     WizardStepTitleDirective,
-    EnableBackLinksDirective
+    EnableBackLinksDirective,
+    WizardStepDirective,
+    WizardCompletionStepDirective
   ],
   imports: [
     CommonModule
@@ -44,7 +48,9 @@ import {EnableBackLinksDirective} from './directives/enable-back-links.directive
     PreviousStepDirective,
     OptionalStepDirective,
     WizardStepTitleDirective,
-    EnableBackLinksDirective
+    EnableBackLinksDirective,
+    WizardStepDirective,
+    WizardCompletionStepDirective
   ]
 })
 export class WizardModule {


### PR DESCRIPTION
This PR fixes #9 by:

- adding a `wizardStep` directive, which can be used to define a wizard step
- adding a `wizardCompletionStep` directive, which can be used to define a wizard completion step

In addition this PR introduces a new parent class for the wizard completion step, called `WizardCompletionStep`, a few more tests and some documentation changes.