### PR TITLE
Add navigation modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,26 @@ The first three layouts are showing circles with or without a background, for ea
 The second two layouts `large-filled-symbols` and `large-empty-symbols` optionally add a symbol in the center of the circle, 
 for each step of your wizard, in the navigation bar, if such a symbol has been defined for the step.
 
+#### \[navigationMode\]
+`ng2-archwizard` supports three different navigation modes:
+- **strict** navigation mode: 
+   The first navigation mode is strict navigation. 
+   This mode describes the status quo, i.e. the current navigation behavior of the wizard. 
+   Currently you can only navigate through the wizard steps in a linear fashion, 
+   where you can only enter the next step if all previous steps have been completed and the exit condition of your current step have been fulfilled. 
+   In this mode it is not possible to jump between different steps, i.e. move to step 3 from step 1, then go to step 2 to finally go to step 4. 
+   The only exception to this rule are optional steps, which a user can skip. 
+   Therefore you are required to do the steps in the order `1 -> 2 -> 3 -> 4`.
+- **semi-strict** navigation mode:
+   The second navigation mode is semi-strict navigation. 
+   This mode lets the user navigate between the steps in any order he likes. 
+   This means that in this navigation mode a user could complete the steps in the order `1 -> 3 -> 2 -> 4`, if the exit conditions have been fulfilled. 
+   This mode has only one restriction, where the user can enter the completion step after he has completed all previous steps. 
+   Again optional steps are skipable in this mode.
+- **free** navigation mode:
+   The third navigation mode is free navigation. 
+   This mode let's the user navigate freely between the different steps, including the completion step, in any order he desires.
+
 #### Parameter overview
 Possible `<wizard>` parameters:
 
@@ -90,6 +110,7 @@ Possible `<wizard>` parameters:
 | ----------------- | ----------------------------------------------------------------------------------------------------- | ------------- |
 | [navBarLocation]  | top &#124; bottom &#124; left &#124; right                                                            | top           |
 | [navBarLayout]    | small &#124; large-filled &#124; large-empty &#124; large-filled-symbols &#124; large-empty-symbols   | small         |
+| [navigationMode]  | strict &#124; semi-strict &#124; free                                                                 | strict        |
 
 ### \<wizard-step\>
 The `<wizard-step></wizard-step>` environment is the wizard step environment. 
@@ -363,6 +384,24 @@ Possible `[wizardCompletionStep]` parameters:
 | [navigationSymbolFontFamily]  | string                                            | null          |
 | (stepEnter)                   | function(MovingDirection)                         | null          |
 
+
+### Accessing the wizard component instance
+Sometimes it's required to access the wizard component directly. 
+In such a case you can get the instance of the used wizard component in your own component via:
+```typescript
+@ViewChild(WizardComponent)
+public wizard: WizardComponent;
+```
+
+In case you've created your own wizard step component with the `wizardStep` directive,
+you can inject the state of your wizard in your own component:
+```typescript
+constructor(private wizardState: WizardState)
+```
+
+Through the `WizardState` you can access the navigation mode of your wizard, 
+which allows you to navigate the wizard programmatically.
+Both instances, the wizard state and the navigation mode, can also be obtained from the injected `WizardComponent`.
 
 ## Example
 You can find an basic example project using `ng2-archwizard` [here](https://madoar.github.io/ng2-archwizard-demo). 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-archwizard",
-  "version": "1.7.0",
+  "version": "1.8.0-develop",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/components/wizard-completion-step.component.spec.ts
+++ b/src/components/components/wizard-completion-step.component.spec.ts
@@ -50,11 +50,11 @@ describe('WizardCompletionStepComponent', () => {
 
   beforeEach(() => {
     wizardTestFixture = TestBed.createComponent(WizardTestComponent);
+    wizardTestFixture.detectChanges();
+
     wizardTest = wizardTestFixture.componentInstance;
     wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
-    navigationMode = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(NavigationMode);
-
-    wizardTestFixture.detectChanges();
+    navigationMode = wizardState.navigationMode;
   });
 
   it('should create', () => {

--- a/src/components/components/wizard-completion-step.component.spec.ts
+++ b/src/components/components/wizard-completion-step.component.spec.ts
@@ -3,11 +3,12 @@
  */
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {WizardCompletionStepComponent} from './wizard-completion-step.component';
-import {ViewChild, Component} from '@angular/core';
-import {WizardComponent} from './wizard.component';
+import {Component} from '@angular/core';
 import {MovingDirection} from '../util/moving-direction.enum';
 import {By} from '@angular/platform-browser';
 import {WizardModule} from '../wizard.module';
+import {WizardState} from '../navigation/wizard-state.model';
+import {NavigationMode} from '../navigation/navigation-mode.interface';
 
 @Component({
   selector: 'test-wizard',
@@ -21,9 +22,6 @@ import {WizardModule} from '../wizard.module';
   `
 })
 class WizardTestComponent {
-  @ViewChild(WizardComponent)
-  public wizard: WizardComponent;
-
   public isValid: any = true;
 
   public eventLog: Array<string> = new Array<string>();
@@ -40,6 +38,8 @@ class WizardTestComponent {
 describe('WizardCompletionStepComponent', () => {
   let wizardTest: WizardTestComponent;
   let wizardTestFixture: ComponentFixture<WizardTestComponent>;
+  let wizardState: WizardState;
+  let navigationMode: NavigationMode;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -51,6 +51,9 @@ describe('WizardCompletionStepComponent', () => {
   beforeEach(() => {
     wizardTestFixture = TestBed.createComponent(WizardTestComponent);
     wizardTest = wizardTestFixture.componentInstance;
+    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    navigationMode = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(NavigationMode);
+
     wizardTestFixture.detectChanges();
   });
 
@@ -62,9 +65,9 @@ describe('WizardCompletionStepComponent', () => {
 
   it('should have correct step title', () => {
     expect(wizardTest).toBeTruthy();
-    expect(wizardTest.wizard.getStepAtIndex(0).title).toBe('Steptitle 1');
-    expect(wizardTest.wizard.getStepAtIndex(1).title).toBe('Steptitle 2');
-    expect(wizardTest.wizard.getStepAtIndex(2).title).toBe('Completion steptitle 3');
+    expect(wizardState.getStepAtIndex(0).title).toBe('Steptitle 1');
+    expect(wizardState.getStepAtIndex(1).title).toBe('Steptitle 2');
+    expect(wizardState.getStepAtIndex(2).title).toBe('Completion steptitle 3');
   });
 
   it('should enter first step after initialisation', () => {
@@ -72,67 +75,67 @@ describe('WizardCompletionStepComponent', () => {
   });
 
   it('should enter completion step after first step', () => {
-    expect(wizardTest.wizard.currentStepIndex).toBe(0);
+    expect(wizardState.currentStepIndex).toBe(0);
 
-    wizardTest.wizard.goToNextStep();
+    navigationMode.goToNextStep();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    expect(wizardState.currentStepIndex).toBe(1);
     expect(wizardTest.eventLog).toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 2']);
 
-    wizardTest.wizard.goToNextStep();
+    navigationMode.goToNextStep();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(2);
+    expect(wizardState.currentStepIndex).toBe(2);
     expect(wizardTest.eventLog).toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 2',
       'exit Forwards 2', 'enter Forwards 3']);
   });
 
   it('should enter completion step after jumping over second optional step', () => {
-    wizardTest.wizard.goToStep(2);
+    navigationMode.goToStep(2);
     wizardTestFixture.detectChanges();
 
     expect(wizardTest.eventLog).toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 3']);
   });
 
   it('should set the wizard as completed after entering the completion step', () => {
-    wizardTest.wizard.goToStep(2);
+    navigationMode.goToStep(2);
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.completed).toBe(true);
+    expect(wizardState.completed).toBe(true);
   });
 
   it('should be unable to leave the completion step', () => {
-    wizardTest.wizard.goToStep(2);
+    navigationMode.goToStep(2);
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.canGoToStep(0)).toBe(false);
-    expect(wizardTest.wizard.canGoToStep(1)).toBe(false);
+    expect(navigationMode.canGoToStep(0)).toBe(false);
+    expect(navigationMode.canGoToStep(1)).toBe(false);
   });
 
 
   it('should not be able to leave the completion step in any direction', () => {
     wizardTest.isValid = false;
 
-    wizardTest.wizard.goToStep(2);
+    navigationMode.goToStep(2);
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(2);
-    expect(wizardTest.wizard.currentStep.canExit).toBe(false);
+    expect(wizardState.currentStepIndex).toBe(2);
+    expect(wizardState.currentStep.canExit).toBe(false);
   });
 
   it('should not leave the completion step if it can\'t be exited', () => {
     wizardTest.isValid = false;
 
-    wizardTest.wizard.goToStep(2);
+    navigationMode.goToStep(2);
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(2);
+    expect(wizardState.currentStepIndex).toBe(2);
 
-    wizardTest.wizard.goToPreviousStep();
+    navigationMode.goToPreviousStep();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(2);
+    expect(wizardState.currentStepIndex).toBe(2);
     expect(wizardTest.eventLog)
       .toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 3', 'enter Stay 3']);
   });

--- a/src/components/components/wizard-completion-step.component.ts
+++ b/src/components/components/wizard-completion-step.component.ts
@@ -120,10 +120,8 @@ export class WizardCompletionStepComponent extends WizardCompletionStep {
 
   /**
    * Constructor
-   * @param wizard The [[WizardComponent]], this completion step is contained inside
    */
-  /* istanbul ignore next */
-  constructor(@Inject(forwardRef(() => WizardComponent)) private wizard: WizardComponent) {
+  constructor() {
     super();
   }
 
@@ -131,7 +129,7 @@ export class WizardCompletionStepComponent extends WizardCompletionStep {
    * @inheritDoc
    */
   enter(direction: MovingDirection): void {
-    this.wizard.completed = true;
+    this.completed = true;
     this.stepEnter.emit(direction);
   }
 
@@ -139,7 +137,8 @@ export class WizardCompletionStepComponent extends WizardCompletionStep {
    * @inheritDoc
    */
   exit(direction: MovingDirection): void {
-    this.wizard.completed = false;
+    // set this completion step as incomplete
+    this.completed = false;
     this.stepExit.emit(direction);
   }
 }

--- a/src/components/components/wizard-completion-step.component.ts
+++ b/src/components/components/wizard-completion-step.component.ts
@@ -119,13 +119,6 @@ export class WizardCompletionStepComponent extends WizardCompletionStep {
   public canExit: ((direction: MovingDirection) => boolean) | boolean = false;
 
   /**
-   * Constructor
-   */
-  constructor() {
-    super();
-  }
-
-  /**
    * @inheritDoc
    */
   enter(direction: MovingDirection): void {

--- a/src/components/components/wizard-completion-step.component.ts
+++ b/src/components/components/wizard-completion-step.component.ts
@@ -101,7 +101,7 @@ export class WizardCompletionStepComponent extends WizardCompletionStep {
   /**
    * @inheritDoc
    */
-  public completed: false;
+  public completed = false;
 
   /**
    * @inheritDoc

--- a/src/components/components/wizard-navigation-bar.component.horizontal.less
+++ b/src/components/components/wizard-navigation-bar.component.horizontal.less
@@ -368,6 +368,10 @@
     li.editing {
       pointer-events: none;
     }
+
+    li.navigable {
+      pointer-events: auto;
+    }
   }
 }
 

--- a/src/components/components/wizard-navigation-bar.component.html
+++ b/src/components/components/wizard-navigation-bar.component.html
@@ -1,15 +1,16 @@
 <ul class="steps-indicator steps-{{numberOfWizardSteps}}">
-  <li *ngFor="let step of wizardSteps"
+  <li *ngFor="let step of wizardSteps, let stepIndex = index"
       [attr.step-symbol]="step.navigationSymbol"
       [ngStyle]="{
         'font-family': step.navigationSymbolFontFamily
       }"
       [ngClass]="{
-        default: !step.optional && !step.completed && !step.selected && !wizard.completed,
-        current: (step.selected && !step.completed && !wizard.completed),
-        done: (step.completed && !step.selected) || wizard.completed,
-        editing: step.selected && step.completed && !wizard.completed,
-        optional: step.optional && !step.completed && !step.selected && !wizard.completed
+        default: !step.optional && !step.completed && !step.selected && !wizardState.completed,
+        current: (step.selected && !step.completed && !wizardState.completed),
+        done: (step.completed && !step.selected) || wizardState.completed,
+        editing: step.selected && step.completed && !wizardState.completed,
+        optional: step.optional && !step.completed && !step.selected && !wizardState.completed,
+        navigable: !step.selected && navigationMode.isNavigable(stepIndex)
   }">
     <div>
       <a [goToStep]="step">

--- a/src/components/components/wizard-navigation-bar.component.spec.ts
+++ b/src/components/components/wizard-navigation-bar.component.spec.ts
@@ -1,9 +1,11 @@
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {ViewChild, Component} from '@angular/core';
+import {Component, ViewChild} from '@angular/core';
 import {WizardNavigationBarComponent} from './wizard-navigation-bar.component';
 import {WizardComponent} from './wizard.component';
 import {By} from '@angular/platform-browser';
 import {WizardModule} from '../wizard.module';
+import {NavigationMode} from '../navigation/navigation-mode.interface';
+import {WizardState} from '../navigation/wizard-state.model';
 
 @Component({
   selector: 'test-wizard',
@@ -17,12 +19,15 @@ import {WizardModule} from '../wizard.module';
 })
 class WizardTestComponent {
   @ViewChild(WizardComponent)
-  public wizard: WizardComponent;
+  wizard: WizardComponent;
 }
 
 describe('WizardNavigationBarComponent', () => {
   let wizardTest: WizardTestComponent;
   let wizardTestFixture: ComponentFixture<WizardTestComponent>;
+
+  let wizardState: WizardState;
+  let navigationMode: NavigationMode;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -34,6 +39,9 @@ describe('WizardNavigationBarComponent', () => {
   beforeEach(() => {
     wizardTestFixture = TestBed.createComponent(WizardTestComponent);
     wizardTest = wizardTestFixture.componentInstance;
+    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    navigationMode = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(NavigationMode);
+
     wizardTestFixture.detectChanges();
   });
 
@@ -81,7 +89,7 @@ describe('WizardNavigationBarComponent', () => {
     const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
 
     // go to second step
-    wizardTest.wizard.goToNextStep();
+    navigationMode.goToNextStep();
     wizardTestFixture.detectChanges();
 
     const allLi = navBar.queryAll(By.css('li'));
@@ -115,9 +123,9 @@ describe('WizardNavigationBarComponent', () => {
     const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
 
     // go to second step
-    wizardTest.wizard.goToNextStep();
+    navigationMode.goToNextStep();
     // go to third step
-    wizardTest.wizard.goToNextStep();
+    navigationMode.goToNextStep();
     wizardTestFixture.detectChanges();
 
     const allLi = navBar.queryAll(By.css('li'));
@@ -151,7 +159,7 @@ describe('WizardNavigationBarComponent', () => {
     const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
 
     // go to third step and jump over the optional second step
-    wizardTest.wizard.goToStep(2);
+    navigationMode.goToStep(2);
     wizardTestFixture.detectChanges();
 
     const allLi = navBar.queryAll(By.css('li'));
@@ -185,9 +193,9 @@ describe('WizardNavigationBarComponent', () => {
     const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
 
     // go to second step
-    wizardTest.wizard.goToNextStep();
+    navigationMode.goToNextStep();
     // go back to first step
-    wizardTest.wizard.goToPreviousStep();
+    navigationMode.goToPreviousStep();
     wizardTestFixture.detectChanges();
 
     const allLi = navBar.queryAll(By.css('li'));
@@ -222,9 +230,9 @@ describe('WizardNavigationBarComponent', () => {
     const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
 
     // go to third step, by jumping over the optional step
-    wizardTest.wizard.goToStep(2);
+    navigationMode.goToStep(2);
     // go back to first step
-    wizardTest.wizard.goToStep(0);
+    navigationMode.goToStep(0);
     wizardTestFixture.detectChanges();
 
     const allLi = navBar.queryAll(By.css('li'));
@@ -259,9 +267,9 @@ describe('WizardNavigationBarComponent', () => {
     const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
 
     // go to third step, by jumping over the optional step
-    wizardTest.wizard.goToStep(2);
+    navigationMode.goToStep(2);
     // go back to second step
-    wizardTest.wizard.goToPreviousStep();
+    navigationMode.goToPreviousStep();
     wizardTestFixture.detectChanges();
 
     const allLi = navBar.queryAll(By.css('li'));
@@ -294,49 +302,49 @@ describe('WizardNavigationBarComponent', () => {
   it('should move back to the first step from the second step, after clicking on the corresponding link', () => {
     const goToFirstStepLink = wizardTestFixture.debugElement.query(By.css('li:nth-child(1) a')).nativeElement;
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(0);
+    expect(wizardState.currentStepIndex).toBe(0);
 
     // go to the second step
-    wizardTest.wizard.goToNextStep();
-    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    navigationMode.goToNextStep();
+    expect(wizardState.currentStepIndex).toBe(1);
 
     // go back to the first step
     goToFirstStepLink.click();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(0);
+    expect(wizardState.currentStepIndex).toBe(0);
   });
 
   it('should move back to the first step from the third step, after clicking on the corresponding link', () => {
     const goToFirstStepLink = wizardTestFixture.debugElement.query(By.css('li:nth-child(1) a')).nativeElement;
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(0);
+    expect(wizardState.currentStepIndex).toBe(0);
 
     // go to the second step
-    wizardTest.wizard.goToStep(2);
-    expect(wizardTest.wizard.currentStepIndex).toBe(2);
+    navigationMode.goToStep(2);
+    expect(wizardState.currentStepIndex).toBe(2);
 
     // go back to the first step
     goToFirstStepLink.click();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(0);
+    expect(wizardState.currentStepIndex).toBe(0);
   });
 
   it('should move back to the second step from the third step, after clicking on the corresponding link', () => {
     const goToSecondStepLink = wizardTestFixture.debugElement.query(By.css('li:nth-child(2) a')).nativeElement;
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(0);
+    expect(wizardState.currentStepIndex).toBe(0);
 
     // go to the second step
-    wizardTest.wizard.goToStep(2);
-    expect(wizardTest.wizard.currentStepIndex).toBe(2);
+    navigationMode.goToStep(2);
+    expect(wizardState.currentStepIndex).toBe(2);
 
     // go back to the first step
     goToSecondStepLink.click();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    expect(wizardState.currentStepIndex).toBe(1);
   });
 
   it('should not move to the second step from the first step, after clicking on the corresponding link', () => {
@@ -344,7 +352,7 @@ describe('WizardNavigationBarComponent', () => {
     const goToSecondStepLink = wizardTestFixture.debugElement.query(By.css('li:nth-child(2)'));
     const goToThirdStepLink = wizardTestFixture.debugElement.query(By.css('li:nth-child(3)'));
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(0);
+    expect(wizardState.currentStepIndex).toBe(0);
     // links contain a class that is not clickable (contains "pointer-events: none;")
     expect(goToFirstStepLink.classes.hasOwnProperty('current')).toBeTruthy('First step label is clickable');
     expect(goToSecondStepLink.classes.hasOwnProperty('default')).toBeTruthy('Second step label is clickable');

--- a/src/components/components/wizard-navigation-bar.component.spec.ts
+++ b/src/components/components/wizard-navigation-bar.component.spec.ts
@@ -38,11 +38,11 @@ describe('WizardNavigationBarComponent', () => {
 
   beforeEach(() => {
     wizardTestFixture = TestBed.createComponent(WizardTestComponent);
+    wizardTestFixture.detectChanges();
+
     wizardTest = wizardTestFixture.componentInstance;
     wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
-    navigationMode = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(NavigationMode);
-
-    wizardTestFixture.detectChanges();
+    navigationMode = wizardState.navigationMode;
   });
 
   it('should create', () => {

--- a/src/components/components/wizard-navigation-bar.component.ts
+++ b/src/components/components/wizard-navigation-bar.component.ts
@@ -1,5 +1,4 @@
 import {Component} from '@angular/core';
-import {WizardComponent} from './wizard.component';
 import {WizardStep} from '../util/wizard-step.interface';
 import {WizardState} from '../navigation/wizard-state.model';
 import {NavigationMode} from '../navigation/navigation-mode.interface';
@@ -24,12 +23,20 @@ import {NavigationMode} from '../navigation/navigation-mode.interface';
 })
 export class WizardNavigationBarComponent {
   /**
+   * The navigation mode
+   *
+   * @returns {NavigationMode}
+   */
+  public get navigationMode(): NavigationMode {
+    return this.wizardState.navigationMode;
+  }
+
+  /**
    * Constructor
    *
    * @param wizardState The state the wizard currently resides in
-   * @param navigationMode The navigation mode used for navigating between different steps
    */
-  constructor(public wizardState: WizardState, public navigationMode: NavigationMode) { }
+  constructor(public wizardState: WizardState) { }
 
   /**
    * Returns all [[WizardStep]]s contained in the wizard

--- a/src/components/components/wizard-navigation-bar.component.ts
+++ b/src/components/components/wizard-navigation-bar.component.ts
@@ -1,6 +1,8 @@
 import {Component} from '@angular/core';
 import {WizardComponent} from './wizard.component';
 import {WizardStep} from '../util/wizard-step.interface';
+import {WizardState} from '../navigation/wizard-state.model';
+import {NavigationMode} from '../navigation/navigation-mode.interface';
 
 /**
  * The `wizard-navigation-bar` component contains the navigation bar inside a [[WizardComponent]].
@@ -24,9 +26,10 @@ export class WizardNavigationBarComponent {
   /**
    * Constructor
    *
-   * @param wizard The wizard, which includes this navigation bar
+   * @param wizardState The state the wizard currently resides in
+   * @param navigationMode The navigation mode used for navigating between different steps
    */
-  constructor(private wizard: WizardComponent) { }
+  constructor(public wizardState: WizardState, public navigationMode: NavigationMode) { }
 
   /**
    * Returns all [[WizardStep]]s contained in the wizard
@@ -34,7 +37,7 @@ export class WizardNavigationBarComponent {
    * @returns {Array<WizardStep>} An array containing all [[WizardStep]]s
    */
   get wizardSteps(): Array<WizardStep> {
-    return this.wizard.wizardSteps.toArray();
+    return this.wizardState.wizardSteps;
   }
 
   /**
@@ -43,6 +46,6 @@ export class WizardNavigationBarComponent {
    * @returns {number} The number of wizard steps to be displayed
    */
   get numberOfWizardSteps(): number {
-    return this.wizard.wizardSteps.length;
+    return this.wizardState.wizardSteps.length;
   }
 }

--- a/src/components/components/wizard-navigation-bar.component.vertical.less
+++ b/src/components/components/wizard-navigation-bar.component.vertical.less
@@ -349,6 +349,10 @@
     li.editing {
       pointer-events: none;
     }
+
+    li.navigable {
+      pointer-events: auto;
+    }
   }
 }
 

--- a/src/components/components/wizard-step.component.spec.ts
+++ b/src/components/components/wizard-step.component.spec.ts
@@ -48,11 +48,11 @@ describe('WizardStepComponent', () => {
 
   beforeEach(() => {
     wizardTestFixture = TestBed.createComponent(WizardTestComponent);
+    wizardTestFixture.detectChanges();
+
     wizardTest = wizardTestFixture.componentInstance;
     wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
-    navigationMode = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(NavigationMode);
-
-    wizardTestFixture.detectChanges();
+    navigationMode = wizardState.navigationMode;
   });
 
   it('should create', () => {

--- a/src/components/components/wizard-step.component.spec.ts
+++ b/src/components/components/wizard-step.component.spec.ts
@@ -1,10 +1,11 @@
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {WizardStepComponent} from './wizard-step.component';
-import {ViewChild, Component} from '@angular/core';
-import {WizardComponent} from './wizard.component';
+import {Component} from '@angular/core';
 import {MovingDirection} from '../util/moving-direction.enum';
 import {By} from '@angular/platform-browser';
 import {WizardModule} from '../wizard.module';
+import {NavigationMode} from '../navigation/navigation-mode.interface';
+import {WizardState} from '../navigation/wizard-state.model';
 
 @Component({
   selector: 'test-wizard',
@@ -18,12 +19,9 @@ import {WizardModule} from '../wizard.module';
   `
 })
 class WizardTestComponent {
-  @ViewChild(WizardComponent)
-  public wizard: WizardComponent;
-
   public isValid: any = true;
 
-  public eventLog: Array<string> = new Array<string>();
+  public eventLog: Array<string> = [];
 
   enterInto(direction: MovingDirection, destination: number): void {
     this.eventLog.push(`enter ${MovingDirection[direction]} ${destination}`);
@@ -38,6 +36,9 @@ describe('WizardStepComponent', () => {
   let wizardTest: WizardTestComponent;
   let wizardTestFixture: ComponentFixture<WizardTestComponent>;
 
+  let wizardState: WizardState;
+  let navigationMode: NavigationMode;
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [WizardTestComponent],
@@ -48,6 +49,9 @@ describe('WizardStepComponent', () => {
   beforeEach(() => {
     wizardTestFixture = TestBed.createComponent(WizardTestComponent);
     wizardTest = wizardTestFixture.componentInstance;
+    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    navigationMode = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(NavigationMode);
+
     wizardTestFixture.detectChanges();
   });
 
@@ -58,9 +62,9 @@ describe('WizardStepComponent', () => {
 
   it('should have correct step title', () => {
     expect(wizardTest).toBeTruthy();
-    expect(wizardTest.wizard.getStepAtIndex(0).title).toBe('Steptitle 1');
-    expect(wizardTest.wizard.getStepAtIndex(1).title).toBe('Steptitle 2');
-    expect(wizardTest.wizard.getStepAtIndex(2).title).toBe('Steptitle 3');
+    expect(wizardState.getStepAtIndex(0).title).toBe('Steptitle 1');
+    expect(wizardState.getStepAtIndex(1).title).toBe('Steptitle 2');
+    expect(wizardState.getStepAtIndex(2).title).toBe('Steptitle 3');
   });
 
   it('should enter first step after initialisation', () => {
@@ -68,15 +72,15 @@ describe('WizardStepComponent', () => {
   });
 
   it('should enter second step after first step', () => {
-    wizardTest.wizard.goToNextStep();
+    navigationMode.goToNextStep();
     wizardTestFixture.detectChanges();
 
     expect(wizardTest.eventLog).toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 2']);
   });
 
   it('should enter first step after exiting second step', () => {
-    wizardTest.wizard.goToNextStep();
-    wizardTest.wizard.goToPreviousStep();
+    navigationMode.goToNextStep();
+    navigationMode.goToPreviousStep();
     wizardTestFixture.detectChanges();
 
     expect(wizardTest.eventLog)
@@ -84,15 +88,15 @@ describe('WizardStepComponent', () => {
   });
 
   it('should enter third step after jumping over second optional step', () => {
-    wizardTest.wizard.goToStep(2);
+    navigationMode.goToStep(2);
     wizardTestFixture.detectChanges();
 
     expect(wizardTest.eventLog).toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 3']);
   });
 
   it('should enter first step after jumping over second optional step two times', () => {
-    wizardTest.wizard.goToStep(2);
-    wizardTest.wizard.goToStep(0);
+    navigationMode.goToStep(2);
+    navigationMode.goToStep(0);
     wizardTestFixture.detectChanges();
 
     expect(wizardTest.eventLog)
@@ -100,8 +104,8 @@ describe('WizardStepComponent', () => {
   });
 
   it('should enter second step after jumping over second optional step and the going back once', () => {
-    wizardTest.wizard.goToStep(2);
-    wizardTest.wizard.goToPreviousStep();
+    navigationMode.goToStep(2);
+    navigationMode.goToPreviousStep();
     wizardTestFixture.detectChanges();
 
     expect(wizardTest.eventLog)
@@ -109,7 +113,7 @@ describe('WizardStepComponent', () => {
   });
 
   it('should stay at first step correctly', () => {
-    wizardTest.wizard.goToStep(0);
+    navigationMode.goToStep(0);
     wizardTestFixture.detectChanges();
 
     expect(wizardTest.eventLog).toEqual(['enter Forwards 1', 'exit Stay 1', 'enter Stay 1']);
@@ -118,60 +122,60 @@ describe('WizardStepComponent', () => {
   it('should not be able to leave the second step in any direction', () => {
     wizardTest.isValid = false;
 
-    wizardTest.wizard.goToNextStep();
+    navigationMode.goToNextStep();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(1);
-    expect(wizardTest.wizard.currentStep.canExit).toBe(false);
+    expect(wizardState.currentStepIndex).toBe(1);
+    expect(wizardState.currentStep.canExit).toBe(false);
   });
 
   it('should not be able to leave the second step in forwards direction', () => {
     wizardTest.isValid = direction => direction !== MovingDirection.Forwards;
 
-    wizardTest.wizard.goToNextStep();
+    navigationMode.goToNextStep();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(1);
-    expect(wizardTest.wizard.canExitStep(wizardTest.wizard.currentStep, MovingDirection.Forwards)).toBe(false);
-    expect(wizardTest.wizard.canExitStep(wizardTest.wizard.currentStep, MovingDirection.Backwards)).toBe(true);
-    expect(wizardTest.wizard.canExitStep(wizardTest.wizard.currentStep, MovingDirection.Stay)).toBe(true);
+    expect(wizardState.currentStepIndex).toBe(1);
+    expect(wizardState.currentStep.canExitStep(MovingDirection.Forwards)).toBe(false);
+    expect(wizardState.currentStep.canExitStep(MovingDirection.Backwards)).toBe(true);
+    expect(wizardState.currentStep.canExitStep(MovingDirection.Stay)).toBe(true);
   });
 
   it('should not be able to leave the second step in backwards direction', () => {
     wizardTest.isValid = direction => direction !== MovingDirection.Backwards;
 
-    wizardTest.wizard.goToNextStep();
+    navigationMode.goToNextStep();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(1);
-    expect(wizardTest.wizard.canExitStep(wizardTest.wizard.currentStep, MovingDirection.Forwards)).toBe(true);
-    expect(wizardTest.wizard.canExitStep(wizardTest.wizard.currentStep, MovingDirection.Backwards)).toBe(false);
-    expect(wizardTest.wizard.canExitStep(wizardTest.wizard.currentStep, MovingDirection.Stay)).toBe(true);
+    expect(wizardState.currentStepIndex).toBe(1);
+    expect(wizardState.currentStep.canExitStep(MovingDirection.Forwards)).toBe(true);
+    expect(wizardState.currentStep.canExitStep(MovingDirection.Backwards)).toBe(false);
+    expect(wizardState.currentStep.canExitStep(MovingDirection.Stay)).toBe(true);
   });
 
   it('should throw error when method "canExit" is malformed', () => {
     wizardTest.isValid = 'String';
 
-    wizardTest.wizard.goToNextStep();
+    navigationMode.goToNextStep();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(1);
-    expect(() => wizardTest.wizard.canExitStep(wizardTest.wizard.currentStep, MovingDirection.Forwards))
+    expect(wizardState.currentStepIndex).toBe(1);
+    expect(() => wizardState.currentStep.canExitStep(MovingDirection.Forwards))
       .toThrow(new Error(`Input value 'String' is neither a boolean nor a function`));
   });
 
   it('should not leave the second step in forward direction if it can\'t be exited', () => {
     wizardTest.isValid = false;
 
-    wizardTest.wizard.goToNextStep();
+    navigationMode.goToNextStep();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    expect(wizardState.currentStepIndex).toBe(1);
 
-    wizardTest.wizard.goToNextStep();
+    navigationMode.goToNextStep();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    expect(wizardState.currentStepIndex).toBe(1);
     expect(wizardTest.eventLog)
       .toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 2', 'exit Stay 2', 'enter Stay 2']);
   });
@@ -179,15 +183,15 @@ describe('WizardStepComponent', () => {
   it('should not leave the second step in backward direction if it can\'t be exited', () => {
     wizardTest.isValid = false;
 
-    wizardTest.wizard.goToNextStep();
+    navigationMode.goToNextStep();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    expect(wizardState.currentStepIndex).toBe(1);
 
-    wizardTest.wizard.goToPreviousStep();
+    navigationMode.goToPreviousStep();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    expect(wizardState.currentStepIndex).toBe(1);
     expect(wizardTest.eventLog)
       .toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 2', 'exit Stay 2', 'enter Stay 2']);
   });
@@ -195,15 +199,15 @@ describe('WizardStepComponent', () => {
   it('should not leave the second step in forward direction if it can\'t be exited in this direction', () => {
     wizardTest.isValid = direction => direction === MovingDirection.Backwards;
 
-    wizardTest.wizard.goToNextStep();
+    navigationMode.goToNextStep();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    expect(wizardState.currentStepIndex).toBe(1);
 
-    wizardTest.wizard.goToNextStep();
+    navigationMode.goToNextStep();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    expect(wizardState.currentStepIndex).toBe(1);
     expect(wizardTest.eventLog)
       .toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 2', 'exit Stay 2', 'enter Stay 2']);
   });
@@ -211,15 +215,15 @@ describe('WizardStepComponent', () => {
   it('should not leave the second step in backward direction if it can\'t be exited in this direction', () => {
     wizardTest.isValid = direction => direction === MovingDirection.Forwards;
 
-    wizardTest.wizard.goToNextStep();
+    navigationMode.goToNextStep();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    expect(wizardState.currentStepIndex).toBe(1);
 
-    wizardTest.wizard.goToPreviousStep();
+    navigationMode.goToPreviousStep();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    expect(wizardState.currentStepIndex).toBe(1);
     expect(wizardTest.eventLog)
       .toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 2', 'exit Stay 2', 'enter Stay 2']);
   });
@@ -227,15 +231,15 @@ describe('WizardStepComponent', () => {
   it('should leave the second step in forward direction if it can be exited in this direction', () => {
     wizardTest.isValid = direction => direction === MovingDirection.Forwards;
 
-    wizardTest.wizard.goToNextStep();
+    navigationMode.goToNextStep();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    expect(wizardState.currentStepIndex).toBe(1);
 
-    wizardTest.wizard.goToNextStep();
+    navigationMode.goToNextStep();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(2);
+    expect(wizardState.currentStepIndex).toBe(2);
     expect(wizardTest.eventLog)
       .toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 2', 'exit Forwards 2', 'enter Forwards 3']);
   });
@@ -243,15 +247,15 @@ describe('WizardStepComponent', () => {
   it('should leave the second step in backward direction if it can be exited in this direction', () => {
     wizardTest.isValid = direction => direction === MovingDirection.Backwards;
 
-    wizardTest.wizard.goToNextStep();
+    navigationMode.goToNextStep();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    expect(wizardState.currentStepIndex).toBe(1);
 
-    wizardTest.wizard.goToPreviousStep();
+    navigationMode.goToPreviousStep();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(0);
+    expect(wizardState.currentStepIndex).toBe(0);
     expect(wizardTest.eventLog)
       .toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 2', 'exit Backwards 2', 'enter Backwards 1']);
   });

--- a/src/components/components/wizard.component.spec.ts
+++ b/src/components/components/wizard.component.spec.ts
@@ -1,8 +1,7 @@
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {QueryList, Component, ViewChild} from '@angular/core';
+import {Component, ViewChild} from '@angular/core';
 import {WizardComponent} from './wizard.component';
 import {By} from '@angular/platform-browser';
-import {WizardStep} from '../util/wizard-step.interface';
 import {WizardModule} from '../wizard.module';
 
 @Component({
@@ -18,26 +17,6 @@ import {WizardModule} from '../wizard.module';
 class WizardTestComponent {
   @ViewChild(WizardComponent)
   public wizard: WizardComponent;
-}
-
-function checkWizardSteps(steps: QueryList<WizardStep>, selectedStepIndex: number) {
-  steps.forEach((step, index, array) => {
-    // Only the selected step should be selected
-    if (index === selectedStepIndex) {
-      expect(step.selected).toBe(true, `the selected wizard step index ${index} is not selected`);
-    } else {
-      expect(step.selected).toBe(false, `the not selected wizard step index ${index} is selected`);
-    }
-
-    // All steps before the selected step need to be completed
-    if (index < selectedStepIndex) {
-      expect(step.completed).toBe(true,
-        `the wizard step ${index} is not completed while the currently selected step index is ${selectedStepIndex}`);
-    } else if (index > selectedStepIndex) {
-      expect(step.completed).toBe(false,
-        `the wizard step ${index} is completed while the currently selected step index is ${selectedStepIndex}`);
-    }
-  });
 }
 
 describe('WizardComponent', () => {
@@ -60,6 +39,7 @@ describe('WizardComponent', () => {
   it('should create', () => {
     expect(wizardTest).toBeTruthy();
     expect(wizardTest.wizard).toBeTruthy();
+
     expect(wizardTestFixture.debugElement.query(By.css('wizard'))).toBeTruthy();
   });
 
@@ -158,217 +138,5 @@ describe('WizardComponent', () => {
       'large-filled': false, 'large-filled-symbols': false, 'large-empty': false, 'large-empty-symbols': false });
     expect(wizard.classes).toEqual({ 'horizontal': false, 'vertical': true });
     expect(wizardStepsDiv.classes).toEqual({ 'wizard-steps': true, 'horizontal': false, 'vertical': true });
-  });
-
-  it('should have steps', () => {
-    expect(wizardTest.wizard.wizardSteps.length).toBe(3);
-  });
-
-  it('should start at first step', () => {
-    expect(wizardTest.wizard.currentStepIndex).toBe(0);
-    expect(wizardTest.wizard.currentStep.title).toBe('Steptitle 1');
-
-    checkWizardSteps(wizardTest.wizard.wizardSteps, 0);
-  });
-
-  it('should return correct step at index', () => {
-    expect(() => wizardTest.wizard.getStepAtIndex(-1))
-      .toThrow(new Error(`Expected a known step, but got stepIndex: -1.`));
-
-    expect(wizardTest.wizard.getStepAtIndex(0).title).toBe('Steptitle 1');
-    expect(wizardTest.wizard.getStepAtIndex(1).title).toBe('Steptitle 2');
-    expect(wizardTest.wizard.getStepAtIndex(2).title).toBe('Steptitle 3');
-
-    // Check that the first wizard step is the only selected one
-    checkWizardSteps(wizardTest.wizard.wizardSteps, 0);
-
-    expect(() => wizardTest.wizard.getStepAtIndex(3))
-      .toThrow(new Error(`Expected a known step, but got stepIndex: 3.`));
-  });
-
-  it('should return correct index at step', () => {
-    expect(wizardTest.wizard.getIndexOfStep(wizardTest.wizard.getStepAtIndex(0))).toBe(0);
-    expect(wizardTest.wizard.getIndexOfStep(wizardTest.wizard.getStepAtIndex(1))).toBe(1);
-    expect(wizardTest.wizard.getIndexOfStep(wizardTest.wizard.getStepAtIndex(2))).toBe(2);
-  });
-
-  it('should return correct can go to step', () => {
-    expect(wizardTest.wizard.canGoToStep(-1)).toBe(false);
-    expect(wizardTest.wizard.canGoToStep(0)).toBe(true);
-    expect(wizardTest.wizard.canGoToStep(1)).toBe(true);
-    expect(wizardTest.wizard.canGoToStep(2)).toBe(false);
-    expect(wizardTest.wizard.canGoToStep(3)).toBe(false);
-  });
-
-  it('should return correct can go to next step', () => {
-    expect(wizardTest.wizard.canGoToNextStep()).toBe(true);
-
-    wizardTest.wizard.goToNextStep();
-
-    checkWizardSteps(wizardTest.wizard.wizardSteps, 1);
-    expect(wizardTest.wizard.canGoToNextStep()).toBe(true);
-
-    wizardTest.wizard.goToNextStep();
-
-    checkWizardSteps(wizardTest.wizard.wizardSteps, 2);
-    expect(wizardTest.wizard.canGoToNextStep()).toBe(false);
-
-    // should do nothing
-    wizardTest.wizard.goToNextStep();
-
-    checkWizardSteps(wizardTest.wizard.wizardSteps, 2);
-  });
-
-  it('should return correct can go to previous step', () => {
-    expect(wizardTest.wizard.canGoToPreviousStep()).toBe(false);
-
-    // should do nothing
-    wizardTest.wizard.goToPreviousStep();
-
-    checkWizardSteps(wizardTest.wizard.wizardSteps, 0);
-
-    wizardTest.wizard.goToNextStep();
-
-    checkWizardSteps(wizardTest.wizard.wizardSteps, 1);
-    expect(wizardTest.wizard.canGoToPreviousStep()).toBe(true);
-  });
-
-  it('should go to step', () => {
-    checkWizardSteps(wizardTest.wizard.wizardSteps, 0);
-
-    wizardTest.wizard.goToStep(1);
-
-    expect(wizardTest.wizard.currentStepIndex).toBe(1);
-    expect(wizardTest.wizard.currentStep).toBe(wizardTest.wizard.getStepAtIndex(1));
-    expect(wizardTest.wizard.currentStep.completed).toBe(false);
-
-    checkWizardSteps(wizardTest.wizard.wizardSteps, 1);
-
-    wizardTest.wizard.goToStep(2);
-
-    expect(wizardTest.wizard.currentStepIndex).toBe(2);
-    expect(wizardTest.wizard.currentStep).toBe(wizardTest.wizard.getStepAtIndex(2));
-    expect(wizardTest.wizard.currentStep.completed).toBe(false);
-
-    checkWizardSteps(wizardTest.wizard.wizardSteps, 2);
-
-    wizardTest.wizard.goToStep(0);
-
-    expect(wizardTest.wizard.currentStepIndex).toBe(0);
-    expect(wizardTest.wizard.currentStep).toBe(wizardTest.wizard.getStepAtIndex(0));
-    expect(wizardTest.wizard.currentStep.completed).toBe(true);
-
-    checkWizardSteps(wizardTest.wizard.wizardSteps, 0);
-
-    wizardTest.wizard.goToStep(1);
-
-    expect(wizardTest.wizard.currentStepIndex).toBe(1);
-    expect(wizardTest.wizard.currentStep).toBe(wizardTest.wizard.getStepAtIndex(1));
-    expect(wizardTest.wizard.currentStep.completed).toBe(false);
-
-    checkWizardSteps(wizardTest.wizard.wizardSteps, 1);
-
-    wizardTest.wizard.goToStep(2);
-
-    expect(wizardTest.wizard.currentStepIndex).toBe(2);
-    expect(wizardTest.wizard.currentStep).toBe(wizardTest.wizard.getStepAtIndex(2));
-    expect(wizardTest.wizard.currentStep.completed).toBe(false);
-
-    checkWizardSteps(wizardTest.wizard.wizardSteps, 2);
-
-    wizardTest.wizard.goToStep(1);
-
-    expect(wizardTest.wizard.currentStepIndex).toBe(1);
-    expect(wizardTest.wizard.currentStep).toBe(wizardTest.wizard.getStepAtIndex(1));
-    expect(wizardTest.wizard.currentStep.completed).toBe(true);
-
-    checkWizardSteps(wizardTest.wizard.wizardSteps, 1);
-  });
-
-  it('should go to next step', () => {
-    wizardTest.wizard.goToNextStep();
-
-    wizardTestFixture.detectChanges();
-
-    expect(wizardTest.wizard.currentStepIndex).toBe(1);
-    expect(wizardTest.wizard.currentStep.title).toBe('Steptitle 2');
-    expect(wizardTest.wizard.currentStep.completed).toBe(false);
-
-    checkWizardSteps(wizardTest.wizard.wizardSteps, 1);
-  });
-
-  it('should go to previous step', () => {
-    expect(wizardTest.wizard.getStepAtIndex(0).completed).toBe(false);
-    checkWizardSteps(wizardTest.wizard.wizardSteps, 0);
-
-    wizardTest.wizard.goToStep(1);
-
-    expect(wizardTest.wizard.getStepAtIndex(0).completed).toBe(true);
-    checkWizardSteps(wizardTest.wizard.wizardSteps, 1);
-
-    wizardTest.wizard.goToPreviousStep();
-
-    expect(wizardTest.wizard.currentStepIndex).toBe(0);
-    expect(wizardTest.wizard.currentStep).toBe(wizardTest.wizard.getStepAtIndex(0));
-
-    checkWizardSteps(wizardTest.wizard.wizardSteps, 0);
-  });
-
-  it('should have next step', () => {
-    checkWizardSteps(wizardTest.wizard.wizardSteps, 0);
-    expect(wizardTest.wizard.hasNextStep()).toBe(true);
-
-    wizardTest.wizard.goToNextStep();
-
-    checkWizardSteps(wizardTest.wizard.wizardSteps, 1);
-    expect(wizardTest.wizard.hasNextStep()).toBe(true);
-
-    wizardTest.wizard.goToNextStep();
-
-    checkWizardSteps(wizardTest.wizard.wizardSteps, 2);
-    expect(wizardTest.wizard.hasNextStep()).toBe(false);
-  });
-
-  it('should have previous step', () => {
-    checkWizardSteps(wizardTest.wizard.wizardSteps, 0);
-    expect(wizardTest.wizard.hasPreviousStep()).toBe(false);
-
-    wizardTest.wizard.goToNextStep();
-
-    checkWizardSteps(wizardTest.wizard.wizardSteps, 1);
-    expect(wizardTest.wizard.hasPreviousStep()).toBe(true);
-
-    wizardTest.wizard.goToNextStep();
-
-    checkWizardSteps(wizardTest.wizard.wizardSteps, 2);
-    expect(wizardTest.wizard.hasPreviousStep()).toBe(true);
-  });
-
-  it('should be last step', () => {
-    checkWizardSteps(wizardTest.wizard.wizardSteps, 0);
-    expect(wizardTest.wizard.isLastStep()).toBe(false);
-
-    wizardTest.wizard.goToNextStep();
-
-    checkWizardSteps(wizardTest.wizard.wizardSteps, 1);
-    expect(wizardTest.wizard.isLastStep()).toBe(false);
-
-    wizardTest.wizard.goToNextStep();
-
-    checkWizardSteps(wizardTest.wizard.wizardSteps, 2);
-    expect(wizardTest.wizard.isLastStep()).toBe(true);
-  });
-
-  it('should reset the wizard correctly', () => {
-    wizardTest.wizard.goToNextStep();
-    wizardTest.wizard.goToNextStep();
-
-    expect(wizardTest.wizard.currentStepIndex).toBe(2);
-    checkWizardSteps(wizardTest.wizard.wizardSteps, 2);
-
-    wizardTest.wizard.reset();
-
-    expect(wizardTest.wizard.currentStepIndex).toBe(0);
-    checkWizardSteps(wizardTest.wizard.wizardSteps, 0);
   });
 });

--- a/src/components/components/wizard.component.spec.ts
+++ b/src/components/components/wizard.component.spec.ts
@@ -32,8 +32,9 @@ describe('WizardComponent', () => {
 
   beforeEach(() => {
     wizardTestFixture = TestBed.createComponent(WizardTestComponent);
-    wizardTest = wizardTestFixture.componentInstance;
     wizardTestFixture.detectChanges();
+
+    wizardTest = wizardTestFixture.componentInstance;
   });
 
   it('should create', () => {

--- a/src/components/components/wizard.component.ts
+++ b/src/components/components/wizard.component.ts
@@ -1,4 +1,4 @@
-import {AfterContentInit, Component, ContentChildren, HostBinding, Input, QueryList} from '@angular/core';
+import {AfterContentInit, Component, ContentChildren, HostBinding, Injector, Input, QueryList} from '@angular/core';
 import {WizardStep} from '../util/wizard-step.interface';
 import {NavigationMode} from '../navigation/navigation-mode.interface';
 import {navigationModeFactory} from '../navigation/navigation-mode.provider';
@@ -104,15 +104,23 @@ export class WizardComponent implements AfterContentInit {
   }
 
   /**
+   * The navigation mode object, that is associated to the input `navigationMode`
+   */
+  public navigation: NavigationMode;
+
+  /**
    * Constructor
    */
-  constructor(private model: WizardState) {
+  constructor(public model: WizardState, private injector: Injector) {
   }
 
   /**
    * Initialization work
    */
   ngAfterContentInit(): void {
+    this.navigation = this.injector.get(NavigationMode);
+
     this.model.initialize(this.wizardSteps);
+    this.navigation.reset();
   }
 }

--- a/src/components/components/wizard.component.ts
+++ b/src/components/components/wizard.component.ts
@@ -1,4 +1,4 @@
-import {AfterContentInit, Component, ContentChildren, HostBinding, Injector, Input, OnInit, QueryList} from '@angular/core';
+import {AfterContentInit, Component, ContentChildren, HostBinding, Input, QueryList} from '@angular/core';
 import {WizardStep} from '../util/wizard-step.interface';
 import {NavigationMode} from '../navigation/navigation-mode.interface';
 import {navigationModeFactory} from '../navigation/navigation-mode.provider';

--- a/src/components/components/wizard.component.ts
+++ b/src/components/components/wizard.component.ts
@@ -1,8 +1,7 @@
-import {AfterContentInit, Component, ContentChildren, HostBinding, Injector, Input, QueryList} from '@angular/core';
+import {AfterContentInit, Component, ContentChildren, HostBinding, Input, QueryList} from '@angular/core';
 import {WizardStep} from '../util/wizard-step.interface';
-import {NavigationMode} from '../navigation/navigation-mode.interface';
-import {navigationModeFactory} from '../navigation/navigation-mode.provider';
 import {WizardState} from '../navigation/wizard-state.model';
+import {NavigationMode} from '../navigation/navigation-mode.interface';
 
 /**
  * The `wizard` component defines the root component of a wizard.
@@ -43,10 +42,7 @@ import {WizardState} from '../navigation/wizard-state.model';
   selector: 'wizard',
   templateUrl: 'wizard.component.html',
   styleUrls: ['wizard.component.less'],
-  providers: [
-    WizardState,
-    { provide: NavigationMode, useFactory: navigationModeFactory, deps: [WizardComponent, WizardState] }
-  ]
+  providers: [WizardState]
 })
 export class WizardComponent implements AfterContentInit {
   /**
@@ -104,23 +100,24 @@ export class WizardComponent implements AfterContentInit {
   }
 
   /**
-   * The navigation mode object, that is associated to the input `navigationMode`
+   * The navigation mode for this wizard
+   *
+   * @returns {NavigationMode}
    */
-  public navigation: NavigationMode;
+  public get navigation(): NavigationMode {
+    return this.model.navigationMode;
+}
 
   /**
    * Constructor
    */
-  constructor(public model: WizardState, private injector: Injector) {
+  constructor(public model: WizardState) {
   }
 
   /**
    * Initialization work
    */
   ngAfterContentInit(): void {
-    this.navigation = this.injector.get(NavigationMode);
-
-    this.model.initialize(this.wizardSteps);
-    this.navigation.reset();
+    this.model.initialize(this.wizardSteps, this.navigationMode);
   }
 }

--- a/src/components/directives/enable-back-links.directive.spec.ts
+++ b/src/components/directives/enable-back-links.directive.spec.ts
@@ -2,11 +2,12 @@
  * Created by marc on 30.06.17.
  */
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {ViewChild, Component} from '@angular/core';
-import {WizardComponent} from '../components/wizard.component';
+import {Component} from '@angular/core';
 import {MovingDirection} from '../util/moving-direction.enum';
 import {By} from '@angular/platform-browser';
 import {WizardModule} from '../wizard.module';
+import {WizardState} from '../navigation/wizard-state.model';
+import {NavigationMode} from '../navigation/navigation-mode.interface';
 
 @Component({
   selector: 'test-wizard',
@@ -27,12 +28,9 @@ import {WizardModule} from '../wizard.module';
   `
 })
 class WizardTestComponent {
-  @ViewChild(WizardComponent)
-  public wizard: WizardComponent;
-
   public isValid: any = true;
 
-  public eventLog: Array<string> = new Array<string>();
+  public eventLog: Array<string> = [];
 
   public completionStepExit: (direction: MovingDirection, source: number) => void = this.exitFrom;
 
@@ -49,6 +47,9 @@ describe('EnableBackLinksDirective', () => {
   let wizardTest: WizardTestComponent;
   let wizardTestFixture: ComponentFixture<WizardTestComponent>;
 
+  let wizardState: WizardState;
+  let navigationMode: NavigationMode;
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [WizardTestComponent],
@@ -59,6 +60,9 @@ describe('EnableBackLinksDirective', () => {
   beforeEach(() => {
     wizardTestFixture = TestBed.createComponent(WizardTestComponent);
     wizardTest = wizardTestFixture.componentInstance;
+    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    navigationMode = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(NavigationMode);
+
     wizardTestFixture.detectChanges();
   });
 
@@ -70,9 +74,9 @@ describe('EnableBackLinksDirective', () => {
 
   it('should have correct step title', () => {
     expect(wizardTest).toBeTruthy();
-    expect(wizardTest.wizard.getStepAtIndex(0).title).toBe('Steptitle 1');
-    expect(wizardTest.wizard.getStepAtIndex(1).title).toBe('Steptitle 2');
-    expect(wizardTest.wizard.getStepAtIndex(2).title).toBe('Completion steptitle 3');
+    expect(wizardState.getStepAtIndex(0).title).toBe('Steptitle 1');
+    expect(wizardState.getStepAtIndex(1).title).toBe('Steptitle 2');
+    expect(wizardState.getStepAtIndex(2).title).toBe('Completion steptitle 3');
   });
 
   it('should enter first step after initialisation', () => {
@@ -80,61 +84,61 @@ describe('EnableBackLinksDirective', () => {
   });
 
   it('should enter completion step after first step', () => {
-    expect(wizardTest.wizard.currentStepIndex).toBe(0);
+    expect(wizardState.currentStepIndex).toBe(0);
 
-    wizardTest.wizard.goToNextStep();
+    navigationMode.goToNextStep();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    expect(wizardState.currentStepIndex).toBe(1);
     expect(wizardTest.eventLog).toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 2']);
 
-    wizardTest.wizard.goToNextStep();
+    navigationMode.goToNextStep();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(2);
+    expect(wizardState.currentStepIndex).toBe(2);
     expect(wizardTest.eventLog).toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 2',
       'exit Forwards 2', 'enter Forwards 3']);
   });
 
   it('should enter completion step after jumping over second optional step', () => {
-    wizardTest.wizard.goToStep(2);
+    navigationMode.goToStep(2);
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.completed).toBe(true);
+    expect(wizardState.completed).toBe(true);
     expect(wizardTest.eventLog).toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 3']);
   });
 
   it('should be able to leave the completion step', () => {
-    wizardTest.wizard.goToStep(2);
+    navigationMode.goToStep(2);
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.canGoToStep(0)).toBe(true);
-    expect(wizardTest.wizard.canGoToStep(1)).toBe(true);
+    expect(navigationMode.canGoToStep(0)).toBe(true);
+    expect(navigationMode.canGoToStep(1)).toBe(true);
   });
 
 
   it('should be able to leave the completion step in any direction', () => {
     wizardTest.isValid = false;
 
-    wizardTest.wizard.goToStep(2);
+    navigationMode.goToStep(2);
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(2);
-    expect(wizardTest.wizard.currentStep.canExit).toBe(true);
+    expect(wizardState.currentStepIndex).toBe(2);
+    expect(wizardState.currentStep.canExit).toBe(true);
   });
 
   it('should leave the completion step', () => {
     wizardTest.isValid = false;
 
-    wizardTest.wizard.goToStep(2);
+    navigationMode.goToStep(2);
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(2);
+    expect(wizardState.currentStepIndex).toBe(2);
 
-    wizardTest.wizard.goToPreviousStep();
+    navigationMode.goToPreviousStep();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    expect(wizardState.currentStepIndex).toBe(1);
     expect(wizardTest.eventLog)
       .toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 3', 'exit Backwards 3', 'enter Backwards 2']);
   });
@@ -145,20 +149,20 @@ describe('EnableBackLinksDirective', () => {
       wizardTest.eventLog.push(`changed exit ${MovingDirection[direction]} ${source}`);
     };
 
-    expect(wizardTest.wizard.completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
 
-    wizardTest.wizard.goToStep(2);
+    navigationMode.goToStep(2);
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(2);
-    expect(wizardTest.wizard.completed).toBe(true);
+    expect(wizardState.currentStepIndex).toBe(2);
+    expect(wizardState.completed).toBe(true);
 
-    wizardTest.wizard.goToPreviousStep();
+    navigationMode.goToPreviousStep();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    expect(wizardState.currentStepIndex).toBe(1);
     expect(wizardTest.eventLog)
       .toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 3', 'changed exit Backwards 3', 'enter Backwards 2']);
-    expect(wizardTest.wizard.completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
   });
 });

--- a/src/components/directives/enable-back-links.directive.spec.ts
+++ b/src/components/directives/enable-back-links.directive.spec.ts
@@ -59,11 +59,11 @@ describe('EnableBackLinksDirective', () => {
 
   beforeEach(() => {
     wizardTestFixture = TestBed.createComponent(WizardTestComponent);
+    wizardTestFixture.detectChanges();
+
     wizardTest = wizardTestFixture.componentInstance;
     wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
-    navigationMode = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(NavigationMode);
-
-    wizardTestFixture.detectChanges();
+    navigationMode = wizardState.navigationMode;
   });
 
   it('should create', () => {

--- a/src/components/directives/go-to-step.directive.spec.ts
+++ b/src/components/directives/go-to-step.directive.spec.ts
@@ -2,11 +2,12 @@
  * Created by marc on 09.01.17.
  */
 import {GoToStepDirective} from './go-to-step.directive';
-import {Component, ViewChild} from '@angular/core';
-import {WizardComponent} from '../components/wizard.component';
-import {ComponentFixture, async, TestBed} from '@angular/core/testing';
+import {Component} from '@angular/core';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {WizardModule} from '../wizard.module';
+import {WizardState} from '../navigation/wizard-state.model';
+import {NavigationMode} from '../navigation/navigation-mode.interface';
 
 @Component({
   selector: 'test-wizard',
@@ -31,14 +32,11 @@ import {WizardModule} from '../wizard.module';
   `
 })
 class WizardTestComponent {
-  @ViewChild(WizardComponent)
-  public wizard: WizardComponent;
-
   public goToSecondStep = 1;
 
   public canExit = true;
 
-  public eventLog: Array<string> = new Array<string>();
+  public eventLog: Array<string> = [];
 
   finalizeStep(stepIndex: number): void {
     this.eventLog.push(`finalize ${stepIndex}`);
@@ -48,6 +46,9 @@ class WizardTestComponent {
 describe('GoToStepDirective', () => {
   let wizardTest: WizardTestComponent;
   let wizardTestFixture: ComponentFixture<WizardTestComponent>;
+
+  let wizardState: WizardState;
+  let navigationMode: NavigationMode;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -59,6 +60,9 @@ describe('GoToStepDirective', () => {
   beforeEach(() => {
     wizardTestFixture = TestBed.createComponent(WizardTestComponent);
     wizardTest = wizardTestFixture.componentInstance;
+    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    navigationMode = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(NavigationMode);
+
     wizardTestFixture.detectChanges();
   });
 
@@ -81,9 +85,9 @@ describe('GoToStepDirective', () => {
     const secondStepGoToButton = wizardTestFixture.debugElement.query(
       By.css('wizard-step[title="Steptitle 2"] > button')).nativeElement;
 
-    const wizardSteps = wizardTest.wizard.wizardSteps.toArray();
+    const wizardSteps = wizardState.wizardSteps;
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(0);
+    expect(wizardState.currentStepIndex).toBe(0);
     expect(wizardSteps[0].selected).toBe(true);
     expect(wizardSteps[1].selected).toBe(false);
     expect(wizardSteps[2].selected).toBe(false);
@@ -92,7 +96,7 @@ describe('GoToStepDirective', () => {
     firstStepGoToButton.click();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    expect(wizardState.currentStepIndex).toBe(1);
     expect(wizardSteps[0].selected).toBe(false);
     expect(wizardSteps[1].selected).toBe(true);
     expect(wizardSteps[2].selected).toBe(false);
@@ -101,7 +105,7 @@ describe('GoToStepDirective', () => {
     secondStepGoToButton.click();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(2);
+    expect(wizardState.currentStepIndex).toBe(2);
     expect(wizardSteps[0].selected).toBe(false);
     expect(wizardSteps[1].selected).toBe(false);
     expect(wizardSteps[2].selected).toBe(true);
@@ -113,9 +117,9 @@ describe('GoToStepDirective', () => {
     const thirdStepGoToButton = wizardTestFixture.debugElement.query(
       By.css('wizard-step[title="Steptitle 3"] > button')).nativeElement;
 
-    const wizardSteps = wizardTest.wizard.wizardSteps.toArray();
+    const wizardSteps = wizardState.wizardSteps;
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(0);
+    expect(wizardState.currentStepIndex).toBe(0);
     expect(wizardSteps[0].selected).toBe(true);
     expect(wizardSteps[1].selected).toBe(false);
     expect(wizardSteps[2].selected).toBe(false);
@@ -124,7 +128,7 @@ describe('GoToStepDirective', () => {
     firstStepGoToButton.click();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(2);
+    expect(wizardState.currentStepIndex).toBe(2);
     expect(wizardSteps[0].selected).toBe(false);
     expect(wizardSteps[1].selected).toBe(false);
     expect(wizardSteps[2].selected).toBe(true);
@@ -133,7 +137,7 @@ describe('GoToStepDirective', () => {
     thirdStepGoToButton.click();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(0);
+    expect(wizardState.currentStepIndex).toBe(0);
     expect(wizardSteps[0].selected).toBe(true);
     expect(wizardSteps[1].selected).toBe(false);
     expect(wizardSteps[2].selected).toBe(false);
@@ -143,9 +147,9 @@ describe('GoToStepDirective', () => {
     const firstStepGoToButton = wizardTestFixture.debugElement.query(
       By.css('wizard-step[title="Steptitle 1"] > button:nth-child(1)')).nativeElement;
 
-    const wizardSteps = wizardTest.wizard.wizardSteps.toArray();
+    const wizardSteps = wizardState.wizardSteps;
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(0);
+    expect(wizardState.currentStepIndex).toBe(0);
     expect(wizardSteps[0].selected).toBe(true);
     expect(wizardSteps[1].selected).toBe(false);
     expect(wizardSteps[2].selected).toBe(false);
@@ -154,7 +158,7 @@ describe('GoToStepDirective', () => {
     firstStepGoToButton.click();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(0);
+    expect(wizardState.currentStepIndex).toBe(0);
     expect(wizardSteps[0].selected).toBe(true);
     expect(wizardSteps[1].selected).toBe(false);
     expect(wizardSteps[2].selected).toBe(false);
@@ -166,21 +170,21 @@ describe('GoToStepDirective', () => {
     const thirdStepGoToButton = wizardTestFixture.debugElement.query(
       By.css('wizard-step[title="Steptitle 3"] > button')).nativeElement;
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(0);
+    expect(wizardState.currentStepIndex).toBe(0);
     expect(wizardTest.eventLog).toEqual([]);
 
     // click button
     firstStepGoToButton.click();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(2);
+    expect(wizardState.currentStepIndex).toBe(2);
     expect(wizardTest.eventLog).toEqual(['finalize 1']);
 
     // click button
     thirdStepGoToButton.click();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(0);
+    expect(wizardState.currentStepIndex).toBe(0);
     expect(wizardTest.eventLog).toEqual(['finalize 1', 'finalize 3']);
   });
 
@@ -217,7 +221,7 @@ describe('GoToStepDirective', () => {
   });
 
   it('should not leave current step if it the destination step can not be entered', () => {
-    expect(wizardTest.wizard.currentStepIndex).toBe(0);
+    expect(wizardState.currentStepIndex).toBe(0);
 
     wizardTest.canExit = false;
     wizardTestFixture.detectChanges();
@@ -229,6 +233,6 @@ describe('GoToStepDirective', () => {
     secondGoToAttribute.click();
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(0);
+    expect(wizardState.currentStepIndex).toBe(0);
   });
 });

--- a/src/components/directives/go-to-step.directive.spec.ts
+++ b/src/components/directives/go-to-step.directive.spec.ts
@@ -59,11 +59,11 @@ describe('GoToStepDirective', () => {
 
   beforeEach(() => {
     wizardTestFixture = TestBed.createComponent(WizardTestComponent);
+    wizardTestFixture.detectChanges();
+
     wizardTest = wizardTestFixture.componentInstance;
     wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
-    navigationMode = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(NavigationMode);
-
-    wizardTestFixture.detectChanges();
+    navigationMode = wizardState.navigationMode;
   });
 
   it('should create an instance', () => {

--- a/src/components/directives/go-to-step.directive.ts
+++ b/src/components/directives/go-to-step.directive.ts
@@ -7,6 +7,8 @@ import {WizardComponent} from '../components/wizard.component';
 import {isStepOffset, StepOffset} from '../util/step-offset.interface';
 import {isNumber, isString} from 'util';
 import {WizardStep} from '../util/wizard-step.interface';
+import {WizardState} from '../navigation/wizard-state.model';
+import {NavigationMode} from '../navigation/navigation-mode.interface';
 
 /**
  * The `goToStep` directive can be used to navigate to a given step.
@@ -59,10 +61,11 @@ export class GoToStepDirective {
   /**
    * Constructor
    *
-   * @param wizard The wizard, which contains this [[GoToStepDirective]]
+   * @param wizardState The wizard state
+   * @param navigationMode The navigation mode, used for the wizard
    * @param wizardStep The wizard step, which contains this [[GoToStepDirective]]
    */
-  constructor(private wizard: WizardComponent, @Optional() private wizardStep: WizardStep) { }
+  constructor(private wizardState: WizardState, private navigationMode: NavigationMode, @Optional() private wizardStep: WizardStep) { }
 
   /**
    * Returns the destination step of this directive as an absolute step index inside the wizard
@@ -78,9 +81,9 @@ export class GoToStepDirective {
     } else if (isString(this.goToStep)) {
       destinationStep = parseInt(this.goToStep as string, 10);
     } else if (isStepOffset(this.goToStep) && this.wizardStep !== null) {
-      destinationStep = this.wizard.getIndexOfStep(this.wizardStep) + this.goToStep.stepOffset;
+      destinationStep = this.wizardState.getIndexOfStep(this.wizardStep) + this.goToStep.stepOffset;
     } else if (this.goToStep instanceof WizardStep) {
-      destinationStep = this.wizard.getIndexOfStep(this.goToStep);
+      destinationStep = this.wizardState.getIndexOfStep(this.goToStep);
     } else {
       throw new Error(`Input 'goToStep' is neither a WizardStep, StepOffset, number or string`);
     }
@@ -93,10 +96,10 @@ export class GoToStepDirective {
    * After this method is called the wizard will try to transition to the `destinationStep`
    */
   @HostListener('click', ['$event']) onClick(): void {
-    if (this.wizard.canGoToStep(this.destinationStep)) {
+    if (this.navigationMode.canGoToStep(this.destinationStep)) {
       this.finalize.emit();
 
-      this.wizard.goToStep(this.destinationStep);
+      this.navigationMode.goToStep(this.destinationStep);
     }
   }
 }

--- a/src/components/directives/go-to-step.directive.ts
+++ b/src/components/directives/go-to-step.directive.ts
@@ -2,8 +2,7 @@
  * Created by marc on 09.01.17.
  */
 
-import {Directive, Output, HostListener, EventEmitter, Input, Optional} from '@angular/core';
-import {WizardComponent} from '../components/wizard.component';
+import {Directive, EventEmitter, HostListener, Input, Optional, Output} from '@angular/core';
 import {isStepOffset, StepOffset} from '../util/step-offset.interface';
 import {isNumber, isString} from 'util';
 import {WizardStep} from '../util/wizard-step.interface';
@@ -56,16 +55,24 @@ export class GoToStepDirective {
    * or a step index as a number or string
    */
   @Input()
-  private goToStep: WizardStep | StepOffset | number | string;
+  public goToStep: WizardStep | StepOffset | number | string;
+
+  /**
+   * The navigation mode
+   *
+   * @returns {NavigationMode}
+   */
+  private get navigationMode(): NavigationMode {
+    return this.wizardState.navigationMode;
+  }
 
   /**
    * Constructor
    *
    * @param wizardState The wizard state
-   * @param navigationMode The navigation mode, used for the wizard
    * @param wizardStep The wizard step, which contains this [[GoToStepDirective]]
    */
-  constructor(private wizardState: WizardState, private navigationMode: NavigationMode, @Optional() private wizardStep: WizardStep) { }
+  constructor(private wizardState: WizardState, @Optional() private wizardStep: WizardStep) { }
 
   /**
    * Returns the destination step of this directive as an absolute step index inside the wizard

--- a/src/components/directives/next-step.directive.spec.ts
+++ b/src/components/directives/next-step.directive.spec.ts
@@ -1,9 +1,10 @@
-import { NextStepDirective } from './next-step.directive';
-import {ViewChild, Component} from '@angular/core';
-import {WizardComponent} from '../components/wizard.component';
-import {ComponentFixture, async, TestBed} from '@angular/core/testing';
+import {NextStepDirective} from './next-step.directive';
+import {Component} from '@angular/core';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {WizardModule} from '../wizard.module';
+import {WizardState} from '../navigation/wizard-state.model';
+import {NavigationMode} from '../navigation/navigation-mode.interface';
 
 @Component({
   selector: 'test-wizard',
@@ -21,10 +22,7 @@ import {WizardModule} from '../wizard.module';
   `
 })
 class WizardTestComponent {
-  @ViewChild(WizardComponent)
-  public wizard: WizardComponent;
-
-  public eventLog: Array<string> = new Array<string>();
+  public eventLog: Array<string> = [];
 
   finalizeStep(stepIndex: number): void {
     this.eventLog.push(`finalize ${stepIndex}`);
@@ -34,6 +32,9 @@ class WizardTestComponent {
 describe('NextStepDirective', () => {
   let wizardTest: WizardTestComponent;
   let wizardTestFixture: ComponentFixture<WizardTestComponent>;
+
+  let wizardState: WizardState;
+  let navigationMode: NavigationMode;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -45,6 +46,9 @@ describe('NextStepDirective', () => {
   beforeEach(() => {
     wizardTestFixture = TestBed.createComponent(WizardTestComponent);
     wizardTest = wizardTestFixture.componentInstance;
+    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    navigationMode = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(NavigationMode);
+
     wizardTestFixture.detectChanges();
   });
 
@@ -63,17 +67,17 @@ describe('NextStepDirective', () => {
     const secondStepButton = wizardTestFixture.debugElement.query(
       By.css('wizard-step[title="Steptitle 2"] > button[nextStep]')).nativeElement;
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(0);
+    expect(wizardState.currentStepIndex).toBe(0);
 
     // go to second step
     firstStepButton.click();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    expect(wizardState.currentStepIndex).toBe(1);
 
     // don't go to third step because it doesn't exist
     secondStepButton.click();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    expect(wizardState.currentStepIndex).toBe(1);
   });
 
   it('should move call finalize correctly when going the next step', () => {

--- a/src/components/directives/next-step.directive.spec.ts
+++ b/src/components/directives/next-step.directive.spec.ts
@@ -45,11 +45,11 @@ describe('NextStepDirective', () => {
 
   beforeEach(() => {
     wizardTestFixture = TestBed.createComponent(WizardTestComponent);
+    wizardTestFixture.detectChanges();
+
     wizardTest = wizardTestFixture.componentInstance;
     wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
-    navigationMode = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(NavigationMode);
-
-    wizardTestFixture.detectChanges();
+    navigationMode = wizardState.navigationMode;
   });
 
   it('should create an instance', () => {

--- a/src/components/directives/next-step.directive.ts
+++ b/src/components/directives/next-step.directive.ts
@@ -1,7 +1,6 @@
-import {Directive, Output, HostListener, EventEmitter} from '@angular/core';
-import {WizardComponent} from '../components/wizard.component';
+import {Directive, EventEmitter, HostListener, Output} from '@angular/core';
 import {NavigationMode} from '../navigation/navigation-mode.interface';
-import {navigationModeFactory} from '../navigation/navigation-mode.provider';
+import {WizardState} from '../navigation/wizard-state.model';
 
 /**
  * The `nextStep` directive can be used to navigate to the next step.
@@ -28,11 +27,20 @@ export class NextStepDirective {
   public finalize = new EventEmitter();
 
   /**
+   * The navigation mode
+   *
+   * @returns {NavigationMode}
+   */
+  private get navigationMode(): NavigationMode {
+    return this.wizardState.navigationMode;
+  }
+
+  /**
    * Constructor
    *
-   * @param navigationMode The navigation mode, used for the wizard
+   * @param wizardState The state of the wizard
    */
-  constructor(private navigationMode: NavigationMode) { }
+  constructor(private wizardState: WizardState) { }
 
   /**
    * Listener method for `click` events on the component with this directive.

--- a/src/components/directives/next-step.directive.ts
+++ b/src/components/directives/next-step.directive.ts
@@ -1,5 +1,7 @@
 import {Directive, Output, HostListener, EventEmitter} from '@angular/core';
 import {WizardComponent} from '../components/wizard.component';
+import {NavigationMode} from '../navigation/navigation-mode.interface';
+import {navigationModeFactory} from '../navigation/navigation-mode.provider';
 
 /**
  * The `nextStep` directive can be used to navigate to the next step.
@@ -28,19 +30,19 @@ export class NextStepDirective {
   /**
    * Constructor
    *
-   * @param wizard The [[WizardComponent]], this directive is used inside
+   * @param navigationMode The navigation mode, used for the wizard
    */
-  constructor(private wizard: WizardComponent) { }
+  constructor(private navigationMode: NavigationMode) { }
 
   /**
    * Listener method for `click` events on the component with this directive.
    * After this method is called the wizard will try to transition to the next step
    */
   @HostListener('click', ['$event']) onClick(): void {
-    if (this.wizard.canGoToNextStep()) {
+    if (this.navigationMode.canGoToNextStep()) {
       this.finalize.emit();
 
-      this.wizard.goToNextStep();
+      this.navigationMode.goToNextStep();
     }
   }
 }

--- a/src/components/directives/optional-step.directive.spec.ts
+++ b/src/components/directives/optional-step.directive.spec.ts
@@ -41,11 +41,11 @@ describe('OptionalStepDirective', () => {
 
   beforeEach(() => {
     wizardTestFixture = TestBed.createComponent(WizardTestComponent);
+    wizardTestFixture.detectChanges();
+
     wizardTest = wizardTestFixture.componentInstance;
     wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
-    navigationMode = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(NavigationMode);
-
-    wizardTestFixture.detectChanges();
+    navigationMode = wizardState.navigationMode;
   });
 
   it('should create an instance', () => {

--- a/src/components/directives/optional-step.directive.spec.ts
+++ b/src/components/directives/optional-step.directive.spec.ts
@@ -1,9 +1,10 @@
-import { OptionalStepDirective } from './optional-step.directive';
-import {Component, ViewChild} from '@angular/core';
-import {WizardComponent} from '../components/wizard.component';
-import {ComponentFixture, TestBed, async} from '@angular/core/testing';
+import {OptionalStepDirective} from './optional-step.directive';
+import {Component} from '@angular/core';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {WizardModule} from '../wizard.module';
+import {WizardState} from '../navigation/wizard-state.model';
+import {NavigationMode} from '../navigation/navigation-mode.interface';
 
 @Component({
   selector: 'test-wizard',
@@ -22,13 +23,14 @@ import {WizardModule} from '../wizard.module';
   `
 })
 class WizardTestComponent {
-  @ViewChild(WizardComponent)
-  public wizard: WizardComponent;
 }
 
 describe('OptionalStepDirective', () => {
   let wizardTest: WizardTestComponent;
   let wizardTestFixture: ComponentFixture<WizardTestComponent>;
+
+  let wizardState: WizardState;
+  let navigationMode: NavigationMode;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -40,6 +42,9 @@ describe('OptionalStepDirective', () => {
   beforeEach(() => {
     wizardTestFixture = TestBed.createComponent(WizardTestComponent);
     wizardTest = wizardTestFixture.componentInstance;
+    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    navigationMode = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(NavigationMode);
+
     wizardTestFixture.detectChanges();
   });
 
@@ -49,8 +54,8 @@ describe('OptionalStepDirective', () => {
   });
 
   it('should set optional correctly', () => {
-    expect(wizardTest.wizard.getStepAtIndex(0).optional).toBe(false);
-    expect(wizardTest.wizard.getStepAtIndex(1).optional).toBe(true);
-    expect(wizardTest.wizard.getStepAtIndex(2).optional).toBe(false);
+    expect(wizardState.getStepAtIndex(0).optional).toBe(false);
+    expect(wizardState.getStepAtIndex(1).optional).toBe(true);
+    expect(wizardState.getStepAtIndex(2).optional).toBe(false);
   });
 });

--- a/src/components/directives/previous-step.directive.spec.ts
+++ b/src/components/directives/previous-step.directive.spec.ts
@@ -1,9 +1,10 @@
-import { PreviousStepDirective } from './previous-step.directive';
-import {ViewChild, Component} from '@angular/core';
-import {WizardComponent} from '../components/wizard.component';
-import {TestBed, async, ComponentFixture} from '@angular/core/testing';
+import {PreviousStepDirective} from './previous-step.directive';
+import {Component} from '@angular/core';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {WizardModule} from '../wizard.module';
+import {WizardState} from '../navigation/wizard-state.model';
+import {NavigationMode} from '../navigation/navigation-mode.interface';
 
 @Component({
   selector: 'test-wizard',
@@ -21,13 +22,14 @@ import {WizardModule} from '../wizard.module';
   `
 })
 class WizardTestComponent {
-  @ViewChild(WizardComponent)
-  public wizard: WizardComponent;
 }
 
 describe('PreviousStepDirective', () => {
   let wizardTest: WizardTestComponent;
   let wizardTestFixture: ComponentFixture<WizardTestComponent>;
+
+  let wizardState: WizardState;
+  let navigationMode: NavigationMode;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -39,6 +41,9 @@ describe('PreviousStepDirective', () => {
   beforeEach(() => {
     wizardTestFixture = TestBed.createComponent(WizardTestComponent);
     wizardTest = wizardTestFixture.componentInstance;
+    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    navigationMode = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(NavigationMode);
+
     wizardTestFixture.detectChanges();
   });
 
@@ -57,22 +62,22 @@ describe('PreviousStepDirective', () => {
     const secondStepButton = wizardTestFixture.debugElement.query(
       By.css('wizard-step[title="Steptitle 2"] > button[previousStep]')).nativeElement;
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(0);
+    expect(wizardState.currentStepIndex).toBe(0);
 
     // don't go to zero (-1) step, because it doesn't exist
     firstStepButton.click();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(0);
+    expect(wizardState.currentStepIndex).toBe(0);
 
     // move to second step to test the previousStep directive
-    wizardTest.wizard.goToStep(1);
+    navigationMode.goToStep(1);
     wizardTestFixture.detectChanges();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(1);
+    expect(wizardState.currentStepIndex).toBe(1);
 
     // go back to first step
     secondStepButton.click();
 
-    expect(wizardTest.wizard.currentStepIndex).toBe(0);
+    expect(wizardState.currentStepIndex).toBe(0);
   });
 });

--- a/src/components/directives/previous-step.directive.spec.ts
+++ b/src/components/directives/previous-step.directive.spec.ts
@@ -40,11 +40,11 @@ describe('PreviousStepDirective', () => {
 
   beforeEach(() => {
     wizardTestFixture = TestBed.createComponent(WizardTestComponent);
+    wizardTestFixture.detectChanges();
+
     wizardTest = wizardTestFixture.componentInstance;
     wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
-    navigationMode = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(NavigationMode);
-
-    wizardTestFixture.detectChanges();
+    navigationMode = wizardState.navigationMode;
   });
 
   it('should create an instance', () => {

--- a/src/components/directives/previous-step.directive.ts
+++ b/src/components/directives/previous-step.directive.ts
@@ -1,7 +1,6 @@
 import {Directive, HostListener} from '@angular/core';
-import {WizardComponent} from '../components/wizard.component';
 import {NavigationMode} from '../navigation/navigation-mode.interface';
-import {navigationModeFactory} from '../navigation/navigation-mode.provider';
+import {WizardState} from '../navigation/wizard-state.model';
 
 /**
  * The `previousStep` directive can be used to navigate to the previous step.
@@ -20,11 +19,20 @@ import {navigationModeFactory} from '../navigation/navigation-mode.provider';
 })
 export class PreviousStepDirective {
   /**
+   * The navigation mode
+   *
+   * @returns {NavigationMode}
+   */
+  private get navigationMode(): NavigationMode {
+    return this.wizardState.navigationMode;
+  }
+
+  /**
    * Constructor
    *
-   * @param navigationMode The navigation mode used for the wizard
+   * @param wizardState The state of the wizard
    */
-  constructor(private navigationMode: NavigationMode) { }
+  constructor(private wizardState: WizardState) { }
 
   /**
    * Listener method for `click` events on the component with this directive.

--- a/src/components/directives/previous-step.directive.ts
+++ b/src/components/directives/previous-step.directive.ts
@@ -1,5 +1,7 @@
 import {Directive, HostListener} from '@angular/core';
 import {WizardComponent} from '../components/wizard.component';
+import {NavigationMode} from '../navigation/navigation-mode.interface';
+import {navigationModeFactory} from '../navigation/navigation-mode.provider';
 
 /**
  * The `previousStep` directive can be used to navigate to the previous step.
@@ -20,17 +22,17 @@ export class PreviousStepDirective {
   /**
    * Constructor
    *
-   * @param wizard The [[WizardComponent]], this directive is used inside
+   * @param navigationMode The navigation mode used for the wizard
    */
-  constructor(private wizard: WizardComponent) { }
+  constructor(private navigationMode: NavigationMode) { }
 
   /**
    * Listener method for `click` events on the component with this directive.
    * After this method is called the wizard will try to transition to the previous step
    */
   @HostListener('click', ['$event']) onClick(): void {
-    if (this.wizard.canGoToPreviousStep()) {
-      this.wizard.goToPreviousStep();
+    if (this.navigationMode.canGoToPreviousStep()) {
+      this.navigationMode.goToPreviousStep();
     }
   }
 }

--- a/src/components/directives/wizard-completion-step.directive.spec.ts
+++ b/src/components/directives/wizard-completion-step.directive.spec.ts
@@ -57,11 +57,11 @@ describe('WizardCompletionStepDirective', () => {
 
   beforeEach(() => {
     wizardTestFixture = TestBed.createComponent(WizardTestComponent);
+    wizardTestFixture.detectChanges();
+
     wizardTest = wizardTestFixture.componentInstance;
     wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
-    navigationMode = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(NavigationMode);
-
-    wizardTestFixture.detectChanges();
+    navigationMode = wizardState.navigationMode;
   });
 
   it('should create', () => {

--- a/src/components/directives/wizard-completion-step.directive.ts
+++ b/src/components/directives/wizard-completion-step.directive.ts
@@ -114,10 +114,8 @@ export class WizardCompletionStepDirective extends WizardCompletionStep {
 
   /**
    * Constructor
-   * @param wizard The [[WizardComponent]], this completion step is contained inside
    */
-  /* istanbul ignore next */
-  constructor(@Inject(forwardRef(() => WizardComponent)) private wizard: WizardComponent) {
+  constructor() {
     super();
   }
 
@@ -125,7 +123,7 @@ export class WizardCompletionStepDirective extends WizardCompletionStep {
    * @inheritDoc
    */
   enter(direction: MovingDirection): void {
-    this.wizard.completed = true;
+    this.completed = true;
     this.stepEnter.emit(direction);
   }
 
@@ -135,8 +133,6 @@ export class WizardCompletionStepDirective extends WizardCompletionStep {
   exit(direction: MovingDirection): void {
     // set this completion step as incomplete
     this.completed = false;
-    // set the wizard itself as incomplete
-    this.wizard.completed = false;
     this.stepExit.emit(direction);
   }
 }

--- a/src/components/directives/wizard-completion-step.directive.ts
+++ b/src/components/directives/wizard-completion-step.directive.ts
@@ -95,7 +95,7 @@ export class WizardCompletionStepDirective extends WizardCompletionStep {
   /**
    * @inheritDoc
    */
-  public completed: false;
+  public completed = false;
 
   /**
    * @inheritDoc
@@ -133,6 +133,9 @@ export class WizardCompletionStepDirective extends WizardCompletionStep {
    * @inheritDoc
    */
   exit(direction: MovingDirection): void {
+    // set this completion step as incomplete
+    this.completed = false;
+    // set the wizard itself as incomplete
     this.wizard.completed = false;
     this.stepExit.emit(direction);
   }

--- a/src/components/directives/wizard-completion-step.directive.ts
+++ b/src/components/directives/wizard-completion-step.directive.ts
@@ -113,13 +113,6 @@ export class WizardCompletionStepDirective extends WizardCompletionStep {
   public canExit: ((direction: MovingDirection) => boolean) | boolean = false;
 
   /**
-   * Constructor
-   */
-  constructor() {
-    super();
-  }
-
-  /**
    * @inheritDoc
    */
   enter(direction: MovingDirection): void {

--- a/src/components/directives/wizard-completion-step.directive.ts
+++ b/src/components/directives/wizard-completion-step.directive.ts
@@ -1,6 +1,5 @@
-import {ContentChild, Directive, EventEmitter, forwardRef, HostBinding, Inject, Input, Output} from '@angular/core';
+import {ContentChild, Directive, EventEmitter, forwardRef, HostBinding, Input, Output} from '@angular/core';
 import {MovingDirection} from '../util/moving-direction.enum';
-import {WizardComponent} from '../components/wizard.component';
 import {WizardStep} from '../util/wizard-step.interface';
 import {WizardStepTitleDirective} from './wizard-step-title.directive';
 import {WizardCompletionStep} from '../util/wizard-completion-step.inferface';

--- a/src/components/directives/wizard-step-title.directive.spec.ts
+++ b/src/components/directives/wizard-step-title.directive.spec.ts
@@ -46,8 +46,9 @@ describe('PreviousStepDirective', () => {
 
   beforeEach(() => {
     wizardTestFixture = TestBed.createComponent(WizardTestComponent);
-    wizardTest = wizardTestFixture.componentInstance;
     wizardTestFixture.detectChanges();
+
+    wizardTest = wizardTestFixture.componentInstance;
   });
 
   it('should create an instance', () => {

--- a/src/components/directives/wizard-step.directive.spec.ts
+++ b/src/components/directives/wizard-step.directive.spec.ts
@@ -73,11 +73,11 @@ describe('WizardStepDirective', () => {
 
   beforeEach(() => {
     wizardTestFixture = TestBed.createComponent(WizardTestComponent);
+    wizardTestFixture.detectChanges();
+
     wizardTest = wizardTestFixture.componentInstance;
     wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
-    navigationMode = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(NavigationMode);
-
-    wizardTestFixture.detectChanges();
+    navigationMode = wizardState.navigationMode;
   });
 
   it('should create', () => {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,5 +5,6 @@
 export {WizardModule} from './wizard.module';
 export * from './components';
 export * from './directives';
+export * from './navigation';
 export * from './util';
 

--- a/src/components/navigation/free-navigation-mode.spec.ts
+++ b/src/components/navigation/free-navigation-mode.spec.ts
@@ -1,7 +1,6 @@
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {Component, ViewChild} from '@angular/core';
 import {By} from '@angular/platform-browser';
-import {WizardStep} from '../util/wizard-step.interface';
 import {WizardModule} from '../wizard.module';
 import {WizardState} from './wizard-state.model';
 import {WizardComponent} from '../components/wizard.component';
@@ -236,6 +235,31 @@ describe('FreeNavigationMode', () => {
     expect(wizardState.currentStepIndex).toBe(0);
     expect(wizardState.getStepAtIndex(0).selected).toBe(true);
     expect(wizardState.getStepAtIndex(0).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
+  });
+
+  it('should reset the wizard correctly', () => {
+    navigationMode.goToNextStep();
+    navigationMode.goToNextStep();
+
+    expect(wizardState.currentStepIndex).toBe(2);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
+
+    navigationMode.reset();
+
+    expect(wizardState.currentStepIndex).toBe(0);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(false);
     expect(wizardState.getStepAtIndex(1).selected).toBe(false);
     expect(wizardState.getStepAtIndex(1).completed).toBe(false);
     expect(wizardState.getStepAtIndex(2).selected).toBe(false);

--- a/src/components/navigation/free-navigation-mode.spec.ts
+++ b/src/components/navigation/free-navigation-mode.spec.ts
@@ -42,7 +42,7 @@ describe('FreeNavigationMode', () => {
 
     wizardTest = wizardTestFixture.componentInstance;
     wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
-    navigationMode = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(NavigationMode);
+    navigationMode = wizardState.navigationMode;
   });
 
   it('should create', () => {

--- a/src/components/navigation/free-navigation-mode.spec.ts
+++ b/src/components/navigation/free-navigation-mode.spec.ts
@@ -1,0 +1,245 @@
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {Component, ViewChild} from '@angular/core';
+import {By} from '@angular/platform-browser';
+import {WizardStep} from '../util/wizard-step.interface';
+import {WizardModule} from '../wizard.module';
+import {WizardState} from './wizard-state.model';
+import {WizardComponent} from '../components/wizard.component';
+import {NavigationMode} from './navigation-mode.interface';
+import {FreeNavigationMode} from './free-navigation-mode';
+
+@Component({
+  selector: 'test-wizard',
+  template: `
+    <wizard navigationMode="free">
+      <wizard-step title='Steptitle 1'>Step 1</wizard-step>
+      <wizard-step title='Steptitle 2'>Step 2</wizard-step>
+      <wizard-step title='Steptitle 3'>Step 3</wizard-step>
+    </wizard>
+  `
+})
+class WizardTestComponent {
+  @ViewChild(WizardComponent)
+  private wizard: WizardComponent;
+}
+
+describe('FreeNavigationMode', () => {
+  let wizardTest: WizardTestComponent;
+  let wizardTestFixture: ComponentFixture<WizardTestComponent>;
+
+  let wizardState: WizardState;
+  let navigationMode: NavigationMode;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [WizardTestComponent],
+      imports: [WizardModule]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    wizardTestFixture = TestBed.createComponent(WizardTestComponent);
+    wizardTestFixture.detectChanges();
+
+    wizardTest = wizardTestFixture.componentInstance;
+    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    navigationMode = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(NavigationMode);
+  });
+
+  it('should create', () => {
+    expect(wizardTest).toBeTruthy();
+    expect(wizardTestFixture.debugElement.query(By.css('wizard'))).toBeTruthy();
+    expect(navigationMode instanceof FreeNavigationMode).toBe(true,
+      'Navigation mode is not an instance of FreeNavigationMode');
+  });
+
+  it('should return correct can go to step', () => {
+    expect(navigationMode.canGoToStep(-1)).toBe(false);
+    expect(navigationMode.canGoToStep(0)).toBe(true);
+    expect(navigationMode.canGoToStep(1)).toBe(true);
+    expect(navigationMode.canGoToStep(2)).toBe(true);
+    expect(navigationMode.canGoToStep(3)).toBe(false);
+  });
+
+  it('should return correct can go to next step', () => {
+    expect(navigationMode.canGoToNextStep()).toBe(true);
+
+    navigationMode.goToNextStep();
+
+    expect(navigationMode.canGoToNextStep()).toBe(true);
+
+    navigationMode.goToNextStep();
+
+    expect(navigationMode.canGoToNextStep()).toBe(false);
+  });
+
+  it('should return correct can go to previous step', () => {
+    expect(navigationMode.canGoToPreviousStep()).toBe(false);
+
+    // should do nothing
+    navigationMode.goToPreviousStep();
+
+    expect(wizardState.currentStepIndex).toBe(0);
+    expect(wizardState.currentStep.selected).toBe(true);
+    expect(wizardState.currentStep.completed).toBe(false);
+    expect(navigationMode.canGoToPreviousStep()).toBe(false);
+
+    navigationMode.goToNextStep();
+
+    expect(navigationMode.canGoToPreviousStep()).toBe(true);
+  });
+
+  it('should go to step', () => {
+    expect(wizardState.currentStepIndex).toBe(0);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+
+    navigationMode.goToStep(1);
+
+    expect(wizardState.currentStepIndex).toBe(1);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
+
+    navigationMode.goToStep(2);
+
+    expect(wizardState.currentStepIndex).toBe(2);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
+
+    navigationMode.goToStep(0);
+
+    expect(wizardState.currentStepIndex).toBe(0);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(true);
+    expect(wizardState.completed).toBe(true);
+
+    navigationMode.goToStep(1);
+
+    expect(wizardState.currentStepIndex).toBe(1);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(true);
+    expect(wizardState.completed).toBe(true);
+
+    navigationMode.goToStep(2);
+
+    expect(wizardState.currentStepIndex).toBe(2);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(true);
+    expect(wizardState.completed).toBe(true);
+
+    navigationMode.goToStep(1);
+
+    expect(wizardState.currentStepIndex).toBe(1);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(true);
+    expect(wizardState.completed).toBe(true);
+  });
+
+  it('should go to next step', () => {
+    navigationMode.goToNextStep();
+
+    wizardTestFixture.detectChanges();
+
+    expect(wizardState.currentStepIndex).toBe(1);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
+  });
+
+  it('should go to previous step', () => {
+    expect(wizardState.getStepAtIndex(0).completed).toBe(false);
+
+    navigationMode.goToStep(1);
+
+    expect(wizardState.currentStepIndex).toBe(1);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
+
+    navigationMode.goToPreviousStep();
+
+    expect(wizardState.currentStepIndex).toBe(0);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
+  });
+
+  it('should stay at the current step', () => {
+    expect(wizardState.getStepAtIndex(0).completed).toBe(false);
+
+    navigationMode.goToPreviousStep();
+
+    expect(wizardState.currentStepIndex).toBe(0);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
+
+    navigationMode.goToStep(-1);
+
+    expect(wizardState.currentStepIndex).toBe(0);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
+
+    navigationMode.goToStep(0);
+
+    expect(wizardState.currentStepIndex).toBe(0);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
+  });
+});

--- a/src/components/navigation/free-navigation-mode.ts
+++ b/src/components/navigation/free-navigation-mode.ts
@@ -3,6 +3,7 @@ import {WizardComponent} from '../components/wizard.component';
 import {WizardStep} from '../util/wizard-step.interface';
 import {MovingDirection} from '../util/moving-direction.enum';
 import {Injectable} from '@angular/core';
+import {WizardState} from './wizard-state.model';
 
 /**
  * A [[NavigationMode]], which allows the user to navigate without any limitations,
@@ -11,13 +12,14 @@ import {Injectable} from '@angular/core';
  * @author Marc Arndt
  */
 @Injectable()
-export class FreeNavigationMode implements NavigationMode {
+export class FreeNavigationMode extends NavigationMode {
   /**
    * Constructor
    *
    * @param {WizardComponent} wizard The wizard, that is configured with this navigation mode
    */
-  constructor(private wizard: WizardComponent) {
+  constructor(wizardState: WizardState) {
+    super(wizardState);
   }
 
   /**
@@ -30,11 +32,10 @@ export class FreeNavigationMode implements NavigationMode {
    * @returns {boolean} True if the destination wizard step can be entered, false otherwise
    */
   canGoToStep(destinationIndex: number): boolean {
-    const movingDirection: MovingDirection = this.wizard.getMovingDirection(destinationIndex);
+    const movingDirection = this.wizardState.getMovingDirection(destinationIndex);
 
-    const canExit = this.wizard.canExitStep(this.wizard.currentStep, movingDirection);
-
-    const hasStep = this.wizard.hasStep(destinationIndex);
+    const canExit = this.wizardState.currentStep.canExitStep(movingDirection);
+    const hasStep = this.wizardState.hasStep(destinationIndex);
 
     return canExit && hasStep;
   }
@@ -54,27 +55,30 @@ export class FreeNavigationMode implements NavigationMode {
    * @param {number} destinationIndex The index of the destination wizard step, which should be entered
    */
   goToStep(destinationIndex: number): void {
-    const destinationStep: WizardStep = this.wizard.getStepAtIndex(destinationIndex);
+    const destinationStep: WizardStep = this.wizardState.getStepAtIndex(destinationIndex);
 
-    const movingDirection: MovingDirection = this.wizard.getMovingDirection(destinationIndex);
+    const movingDirection: MovingDirection = this.wizardState.getMovingDirection(destinationIndex);
 
     // the current step can be exited in the given direction
     if (this.canGoToStep(destinationIndex)) {
       // leave current step
-      this.wizard.currentStep.completed = true;
-      this.wizard.currentStep.exit(movingDirection);
-      this.wizard.currentStep.selected = false;
+      this.wizardState.currentStep.completed = true;
+      this.wizardState.currentStep.exit(movingDirection);
+      this.wizardState.currentStep.selected = false;
 
-      this.wizard.currentStepIndex = destinationIndex;
-      this.wizard.currentStep = destinationStep;
+      this.wizardState.currentStepIndex = destinationIndex;
 
       // go to next step
-      this.wizard.currentStep.enter(movingDirection);
-      this.wizard.currentStep.selected = true;
+      this.wizardState.currentStep.enter(movingDirection);
+      this.wizardState.currentStep.selected = true;
     } else {
       // if the current step can't be left, reenter the current step
-      this.wizard.currentStep.exit(MovingDirection.Stay);
-      this.wizard.currentStep.enter(MovingDirection.Stay);
+      this.wizardState.currentStep.exit(MovingDirection.Stay);
+      this.wizardState.currentStep.enter(MovingDirection.Stay);
     }
+  }
+
+  isNavigable(destinationIndex: number): boolean {
+    return true;
   }
 }

--- a/src/components/navigation/free-navigation-mode.ts
+++ b/src/components/navigation/free-navigation-mode.ts
@@ -1,0 +1,80 @@
+import {NavigationMode} from './navigation-mode.interface';
+import {WizardComponent} from '../components/wizard.component';
+import {WizardStep} from '../util/wizard-step.interface';
+import {MovingDirection} from '../util/moving-direction.enum';
+import {Injectable} from '@angular/core';
+
+/**
+ * A [[NavigationMode]], which allows the user to navigate without any limitations,
+ * as long as the current step can be exited in the given direction
+ *
+ * @author Marc Arndt
+ */
+@Injectable()
+export class FreeNavigationMode implements NavigationMode {
+  /**
+   * Constructor
+   *
+   * @param {WizardComponent} wizard The wizard, that is configured with this navigation mode
+   */
+  constructor(private wizard: WizardComponent) {
+  }
+
+  /**
+   * Checks whether the wizard can be transitioned to the given destination step.
+   * A destination wizard step can be entered if:
+   * - it exists
+   * - the current step can be exited in the direction of the destination step
+   *
+   * @param {number} destinationIndex The index of the destination wizard step
+   * @returns {boolean} True if the destination wizard step can be entered, false otherwise
+   */
+  canGoToStep(destinationIndex: number): boolean {
+    const movingDirection: MovingDirection = this.wizard.getMovingDirection(destinationIndex);
+
+    const canExit = this.wizard.canExitStep(this.wizard.currentStep, movingDirection);
+
+    const hasStep = this.wizard.hasStep(destinationIndex);
+
+    return canExit && hasStep;
+  }
+
+  /**
+   * Tries to enter the wizard step with the given destination index.
+   * When entering the destination step, the following actions are done:
+   * - the old current step is set as completed
+   * - the old current step is set as unselected
+   * - the old current step is exited
+   * - the destination step is set as selected
+   * - the destination step is entered
+   *
+   * When the destination step couldn't be entered, the following actions are done:
+   * - the current step is exited and entered in the direction `MovingDirection.Stay`
+   *
+   * @param {number} destinationIndex The index of the destination wizard step, which should be entered
+   */
+  goToStep(destinationIndex: number): void {
+    const destinationStep: WizardStep = this.wizard.getStepAtIndex(destinationIndex);
+
+    const movingDirection: MovingDirection = this.wizard.getMovingDirection(destinationIndex);
+
+    // the current step can be exited in the given direction
+    if (this.canGoToStep(destinationIndex)) {
+      // leave current step
+      this.wizard.currentStep.completed = true;
+      this.wizard.currentStep.exit(movingDirection);
+      this.wizard.currentStep.selected = false;
+
+      this.wizard.currentStepIndex = destinationIndex;
+      this.wizard.currentStep = destinationStep;
+
+      // go to next step
+      this.wizard.currentStep.enter(movingDirection);
+      this.wizard.currentStep.selected = true;
+    } else {
+      // if the current step can't be left, reenter the current step
+      this.wizard.currentStep.exit(MovingDirection.Stay);
+      this.wizard.currentStep.enter(MovingDirection.Stay);
+    }
+  }
+}

--- a/src/components/navigation/free-navigation-mode.ts
+++ b/src/components/navigation/free-navigation-mode.ts
@@ -1,6 +1,5 @@
 import {NavigationMode} from './navigation-mode.interface';
 import {MovingDirection} from '../util/moving-direction.enum';
-import {Injectable} from '@angular/core';
 import {WizardState} from './wizard-state.model';
 
 /**
@@ -9,7 +8,6 @@ import {WizardState} from './wizard-state.model';
  *
  * @author Marc Arndt
  */
-@Injectable()
 export class FreeNavigationMode extends NavigationMode {
   /**
    * Constructor

--- a/src/components/navigation/free-navigation-mode.ts
+++ b/src/components/navigation/free-navigation-mode.ts
@@ -55,8 +55,6 @@ export class FreeNavigationMode extends NavigationMode {
    * @param {number} destinationIndex The index of the destination wizard step, which should be entered
    */
   goToStep(destinationIndex: number): void {
-    const destinationStep: WizardStep = this.wizardState.getStepAtIndex(destinationIndex);
-
     const movingDirection: MovingDirection = this.wizardState.getMovingDirection(destinationIndex);
 
     // the current step can be exited in the given direction

--- a/src/components/navigation/free-navigation-mode.ts
+++ b/src/components/navigation/free-navigation-mode.ts
@@ -1,6 +1,4 @@
 import {NavigationMode} from './navigation-mode.interface';
-import {WizardComponent} from '../components/wizard.component';
-import {WizardStep} from '../util/wizard-step.interface';
 import {MovingDirection} from '../util/moving-direction.enum';
 import {Injectable} from '@angular/core';
 import {WizardState} from './wizard-state.model';
@@ -16,7 +14,7 @@ export class FreeNavigationMode extends NavigationMode {
   /**
    * Constructor
    *
-   * @param {WizardComponent} wizard The wizard, that is configured with this navigation mode
+   * @param {WizardState} wizardState The model/state of the wizard, that is configured with this navigation mode
    */
   constructor(wizardState: WizardState) {
     super(wizardState);

--- a/src/components/navigation/index.ts
+++ b/src/components/navigation/index.ts
@@ -1,0 +1,6 @@
+export {NavigationMode} from './navigation-mode.interface';
+export * from './navigation-mode.provider';
+export {StrictNavigationMode} from './strict-navigation-mode';
+export {SemiStrictNavigationMode} from './semi-strict-navigation-mode';
+export {FreeNavigationMode} from './free-navigation-mode';
+export {WizardState} from './wizard-state.model'

--- a/src/components/navigation/navigation-mode.interface.ts
+++ b/src/components/navigation/navigation-mode.interface.ts
@@ -1,17 +1,22 @@
+import {WizardState} from './wizard-state.model';
+
 /**
  * An interface describing the basic functionality, which must be provided by a navigation mode.
  * A navigation mode manages the navigation between different wizard steps, this contains the validation, if a step transition can be done
  *
  * @author Marc Arndt
  */
-export interface NavigationMode {
+export abstract class NavigationMode {
+  constructor(protected wizardState: WizardState) {
+  }
+
   /**
    * Checks, whether a wizard step, as defined by the given destination index, can be transitioned to.
    *
    * @param {number} destinationIndex The index of the destination step
    * @returns {boolean} True if the destination step can be transitioned to, false otherwise
    */
-  canGoToStep(destinationIndex: number): boolean;
+  abstract canGoToStep(destinationIndex: number): boolean;
 
   /**
    * Tries to transition to the wizard step, as denoted by the given destination index.
@@ -19,5 +24,54 @@ export interface NavigationMode {
    *
    * @param {number} destinationIndex The index of the destination step
    */
-  goToStep(destinationIndex: number): void;
+  abstract goToStep(destinationIndex: number): void;
+
+  /**
+   * Checks, whether the wizard step, located at the given index, is can be navigated to
+   *
+   * @param {number} destinationIndex The index of the destination step
+   * @returns {boolean} True if the step can be navigated to, false otherwise
+   */
+  abstract isNavigable(destinationIndex: number): boolean;
+
+  /**
+   * Tries to transition the wizard to the previous step from the `currentStep`
+   */
+  goToPreviousStep(): void {
+    if (this.wizardState.hasPreviousStep()) {
+      this.goToStep(this.wizardState.currentStepIndex - 1);
+    }
+  }
+
+  /**
+   * Tries to transition the wizard to the next step from the `currentStep`
+   */
+  goToNextStep(): void {
+    if (this.wizardState.hasNextStep()) {
+      this.goToStep(this.wizardState.currentStepIndex + 1);
+    }
+  }
+
+  /**
+   * Checks if it's possible to transition to the previous step from the `currentStep`
+   *
+   * @returns {boolean} True if it's possible to transition to the previous step, false otherwise
+   */
+  canGoToPreviousStep(): boolean {
+    const previousStepIndex = this.wizardState.currentStepIndex - 1;
+
+    return this.wizardState.hasStep(previousStepIndex) && this.canGoToStep(previousStepIndex);
+  }
+
+  /**
+   * Checks if it's possible to transition to the next step from the `currentStep`
+   *
+   * @returns {boolean} True if it's possible to transition to the next step, false otherwise
+   */
+  canGoToNextStep(): boolean {
+    const nextStepIndex = this.wizardState.currentStepIndex + 1;
+
+    return this.wizardState.hasStep(nextStepIndex) && this.canGoToStep(nextStepIndex);
+  }
+
 }

--- a/src/components/navigation/navigation-mode.interface.ts
+++ b/src/components/navigation/navigation-mode.interface.ts
@@ -1,0 +1,23 @@
+/**
+ * An interface describing the basic functionality, which must be provided by a navigation mode.
+ * A navigation mode manages the navigation between different wizard steps, this contains the validation, if a step transition can be done
+ *
+ * @author Marc Arndt
+ */
+export interface NavigationMode {
+  /**
+   * Checks, whether a wizard step, as defined by the given destination index, can be transitioned to.
+   *
+   * @param {number} destinationIndex The index of the destination step
+   * @returns {boolean} True if the destination step can be transitioned to, false otherwise
+   */
+  canGoToStep(destinationIndex: number): boolean;
+
+  /**
+   * Tries to transition to the wizard step, as denoted by the given destination index.
+   * If this is not possible, the current wizard step should be exited and then reentered with `MovingDirection.Stay`
+   *
+   * @param {number} destinationIndex The index of the destination step
+   */
+  goToStep(destinationIndex: number): void;
+}

--- a/src/components/navigation/navigation-mode.interface.ts
+++ b/src/components/navigation/navigation-mode.interface.ts
@@ -1,4 +1,5 @@
 import {WizardState} from './wizard-state.model';
+import {MovingDirection} from '../util/moving-direction.enum';
 
 /**
  * An interface describing the basic functionality, which must be provided by a navigation mode.
@@ -74,4 +75,21 @@ export abstract class NavigationMode {
     return this.wizardState.hasStep(nextStepIndex) && this.canGoToStep(nextStepIndex);
   }
 
+  /**
+   * Resets the state of this wizard.
+   * A reset transitions the wizard automatically to the first step and sets all steps as incomplete.
+   * In addition the whole wizard is set as incomplete
+   */
+  reset(): void {
+    // reset the step internal state
+    this.wizardState.wizardSteps.forEach(step => {
+      step.completed = false;
+      step.selected = false;
+    });
+
+    // set the first step as the current step
+    this.wizardState.currentStepIndex = 0;
+    this.wizardState.currentStep.selected = true;
+    this.wizardState.currentStep.enter(MovingDirection.Forwards);
+  }
 }

--- a/src/components/navigation/navigation-mode.provider.ts
+++ b/src/components/navigation/navigation-mode.provider.ts
@@ -1,0 +1,38 @@
+import {WizardComponent} from '../components/wizard.component';
+import {FreeNavigationMode} from './free-navigation-mode';
+import {SemiStrictNavigationMode} from './semi-strict-navigation-mode';
+import {StrictNavigationMode} from './strict-navigation-mode';
+import {forwardRef, InjectionToken, Type} from '@angular/core';
+import {NavigationMode} from './navigation-mode.interface';
+
+/**
+ * An injection token to be used to inject a [[NavigationMode]] in an angular component or directive
+ * @type {InjectionToken<NavigationMode>}
+ */
+export let NAVIGATION_MODE = new InjectionToken<NavigationMode>('wizard.navigation.mode');
+
+/**
+ * A factory method used to create [[NavigationMode]] instances
+ * @param {WizardComponent} wizard
+ * @returns {any}
+ */
+let navigationModeFactory = (wizard: WizardComponent) => {
+  switch (this.navigationMode) {
+    case 'free':
+      return new FreeNavigationMode(wizard);
+    case 'semi-strict':
+      return new SemiStrictNavigationMode(wizard);
+    case 'strict':
+    default:
+      return new StrictNavigationMode(wizard);
+  }
+};
+
+/**
+ * A provider for [[NavigationMode]] instances
+ */
+export let navigationModeProvider = {
+  provide: NAVIGATION_MODE,
+  useFactory: navigationModeFactory,
+  deps: [forwardRef(() => WizardComponent)]
+};

--- a/src/components/navigation/navigation-mode.provider.ts
+++ b/src/components/navigation/navigation-mode.provider.ts
@@ -2,37 +2,25 @@ import {WizardComponent} from '../components/wizard.component';
 import {FreeNavigationMode} from './free-navigation-mode';
 import {SemiStrictNavigationMode} from './semi-strict-navigation-mode';
 import {StrictNavigationMode} from './strict-navigation-mode';
-import {forwardRef, InjectionToken, Type} from '@angular/core';
-import {NavigationMode} from './navigation-mode.interface';
 
-/**
- * An injection token to be used to inject a [[NavigationMode]] in an angular component or directive
- * @type {InjectionToken<NavigationMode>}
- */
-export let NAVIGATION_MODE = new InjectionToken<NavigationMode>('wizard.navigation.mode');
+import {NavigationMode} from './navigation-mode.interface';
+import {WizardState} from './wizard-state.model';
 
 /**
  * A factory method used to create [[NavigationMode]] instances
- * @param {WizardComponent} wizard
- * @returns {any}
+ *
+ * @param {WizardComponent} wizard The wizard, for which a navigation mode will be created
+ * @param {WizardState} wizardState The wizard state of the wizard
+ * @returns {NavigationMode} The created [[NavigationMode]]
  */
-let navigationModeFactory = (wizard: WizardComponent) => {
-  switch (this.navigationMode) {
+export function navigationModeFactory(wizard: WizardComponent, wizardState: WizardState): NavigationMode {
+  switch (wizard.navigationMode) {
     case 'free':
-      return new FreeNavigationMode(wizard);
+      return new FreeNavigationMode(wizardState);
     case 'semi-strict':
-      return new SemiStrictNavigationMode(wizard);
+      return new SemiStrictNavigationMode(wizardState);
     case 'strict':
     default:
-      return new StrictNavigationMode(wizard);
+      return new StrictNavigationMode(wizardState);
   }
-};
-
-/**
- * A provider for [[NavigationMode]] instances
- */
-export let navigationModeProvider = {
-  provide: NAVIGATION_MODE,
-  useFactory: navigationModeFactory,
-  deps: [forwardRef(() => WizardComponent)]
 };

--- a/src/components/navigation/navigation-mode.provider.ts
+++ b/src/components/navigation/navigation-mode.provider.ts
@@ -13,8 +13,8 @@ import {WizardState} from './wizard-state.model';
  * @param {WizardState} wizardState The wizard state of the wizard
  * @returns {NavigationMode} The created [[NavigationMode]]
  */
-export function navigationModeFactory(wizard: WizardComponent, wizardState: WizardState): NavigationMode {
-  switch (wizard.navigationMode) {
+export function navigationModeFactory(navigationMode: string, wizardState: WizardState): NavigationMode {
+  switch (navigationMode) {
     case 'free':
       return new FreeNavigationMode(wizardState);
     case 'semi-strict':

--- a/src/components/navigation/semi-strict-navigation-mode.spec.ts
+++ b/src/components/navigation/semi-strict-navigation-mode.spec.ts
@@ -1,0 +1,244 @@
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {Component, ViewChild} from '@angular/core';
+import {By} from '@angular/platform-browser';
+import {WizardModule} from '../wizard.module';
+import {WizardState} from './wizard-state.model';
+import {WizardComponent} from '../components/wizard.component';
+import {NavigationMode} from './navigation-mode.interface';
+import {SemiStrictNavigationMode} from './semi-strict-navigation-mode';
+
+@Component({
+  selector: 'test-wizard',
+  template: `
+    <wizard navigationMode="semi-strict">
+      <wizard-step title='Steptitle 1'>Step 1</wizard-step>
+      <wizard-step title='Steptitle 2'>Step 2</wizard-step>
+      <wizard-completion-step enableBackLinks title='Completion Steptitle'>Step 3</wizard-completion-step>
+    </wizard>
+  `
+})
+class WizardTestComponent {
+  @ViewChild(WizardComponent)
+  private wizard: WizardComponent;
+}
+
+describe('SemiStrictNavigationMode', () => {
+  let wizardTest: WizardTestComponent;
+  let wizardTestFixture: ComponentFixture<WizardTestComponent>;
+
+  let wizardState: WizardState;
+  let navigationMode: NavigationMode;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [WizardTestComponent],
+      imports: [WizardModule]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    wizardTestFixture = TestBed.createComponent(WizardTestComponent);
+    wizardTestFixture.detectChanges();
+
+    wizardTest = wizardTestFixture.componentInstance;
+    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    navigationMode = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(NavigationMode);
+  });
+
+  it('should create', () => {
+    expect(wizardTest).toBeTruthy();
+    expect(wizardTestFixture.debugElement.query(By.css('wizard'))).toBeTruthy();
+    expect(navigationMode instanceof SemiStrictNavigationMode).toBe(true,
+      'Navigation mode is not an instance of SemiStrictNavigationMode');
+  });
+
+  it('should return correct can go to step', () => {
+    expect(navigationMode.canGoToStep(-1)).toBe(false);
+    expect(navigationMode.canGoToStep(0)).toBe(true);
+    expect(navigationMode.canGoToStep(1)).toBe(true);
+    expect(navigationMode.canGoToStep(2)).toBe(false);
+    expect(navigationMode.canGoToStep(3)).toBe(false);
+  });
+
+  it('should return correct can go to next step', () => {
+    expect(navigationMode.canGoToNextStep()).toBe(true);
+
+    navigationMode.goToNextStep();
+
+    expect(navigationMode.canGoToNextStep()).toBe(true);
+
+    navigationMode.goToNextStep();
+
+    expect(navigationMode.canGoToNextStep()).toBe(false);
+  });
+
+  it('should return correct can go to previous step', () => {
+    expect(navigationMode.canGoToPreviousStep()).toBe(false);
+
+    // should do nothing
+    navigationMode.goToPreviousStep();
+
+    expect(wizardState.currentStepIndex).toBe(0);
+    expect(wizardState.currentStep.selected).toBe(true);
+    expect(wizardState.currentStep.completed).toBe(false);
+    expect(navigationMode.canGoToPreviousStep()).toBe(false);
+
+    navigationMode.goToNextStep();
+
+    expect(navigationMode.canGoToPreviousStep()).toBe(true);
+  });
+
+  it('should go to step', () => {
+    expect(wizardState.currentStepIndex).toBe(0);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+
+    navigationMode.goToStep(1);
+
+    expect(wizardState.currentStepIndex).toBe(1);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
+
+    navigationMode.goToStep(2);
+
+    expect(wizardState.currentStepIndex).toBe(2);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(true);
+    expect(wizardState.completed).toBe(true);
+
+    navigationMode.goToStep(0);
+
+    expect(wizardState.currentStepIndex).toBe(0);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
+
+    navigationMode.goToStep(1);
+
+    expect(wizardState.currentStepIndex).toBe(1);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
+
+    navigationMode.goToStep(2);
+
+    expect(wizardState.currentStepIndex).toBe(2);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(true);
+    expect(wizardState.completed).toBe(true);
+
+    navigationMode.goToStep(1);
+
+    expect(wizardState.currentStepIndex).toBe(1);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
+  });
+
+  it('should go to next step', () => {
+    navigationMode.goToNextStep();
+
+    wizardTestFixture.detectChanges();
+
+    expect(wizardState.currentStepIndex).toBe(1);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
+  });
+
+  it('should go to previous step', () => {
+    expect(wizardState.getStepAtIndex(0).completed).toBe(false);
+
+    navigationMode.goToStep(1);
+
+    expect(wizardState.currentStepIndex).toBe(1);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
+
+    navigationMode.goToPreviousStep();
+
+    expect(wizardState.currentStepIndex).toBe(0);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
+  });
+
+  it('should stay at the current step', () => {
+    expect(wizardState.getStepAtIndex(0).completed).toBe(false);
+
+    navigationMode.goToPreviousStep();
+
+    expect(wizardState.currentStepIndex).toBe(0);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
+
+    navigationMode.goToStep(-1);
+
+    expect(wizardState.currentStepIndex).toBe(0);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
+
+    navigationMode.goToStep(0);
+
+    expect(wizardState.currentStepIndex).toBe(0);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
+  });
+});

--- a/src/components/navigation/semi-strict-navigation-mode.spec.ts
+++ b/src/components/navigation/semi-strict-navigation-mode.spec.ts
@@ -42,7 +42,7 @@ describe('SemiStrictNavigationMode', () => {
 
     wizardTest = wizardTestFixture.componentInstance;
     wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
-    navigationMode = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(NavigationMode);
+    navigationMode = wizardState.navigationMode;
   });
 
   it('should create', () => {

--- a/src/components/navigation/semi-strict-navigation-mode.spec.ts
+++ b/src/components/navigation/semi-strict-navigation-mode.spec.ts
@@ -241,4 +241,29 @@ describe('SemiStrictNavigationMode', () => {
     expect(wizardState.getStepAtIndex(2).completed).toBe(false);
     expect(wizardState.completed).toBe(false);
   });
+
+  it('should reset the wizard correctly', () => {
+    navigationMode.goToNextStep();
+    navigationMode.goToNextStep();
+
+    expect(wizardState.currentStepIndex).toBe(2);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(true);
+    expect(wizardState.completed).toBe(true);
+
+    navigationMode.reset();
+
+    expect(wizardState.currentStepIndex).toBe(0);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
+  });
 });

--- a/src/components/navigation/semi-strict-navigation-mode.ts
+++ b/src/components/navigation/semi-strict-navigation-mode.ts
@@ -1,5 +1,4 @@
 import {NavigationMode} from './navigation-mode.interface';
-import {WizardComponent} from '../components/wizard.component';
 import {WizardStep} from '../util/wizard-step.interface';
 import {MovingDirection} from '../util/moving-direction.enum';
 import {WizardCompletionStep} from '../util/wizard-completion-step.inferface';
@@ -19,7 +18,7 @@ export class SemiStrictNavigationMode extends NavigationMode {
   /**
    * Constructor
    *
-   * @param {WizardComponent} wizard The wizard, that is configured with this navigation mode
+   * @param {WizardState} wizardState The model/state of the wizard, that is configured with this navigation mode
    */
   constructor(wizardState: WizardState) {
     super(wizardState);

--- a/src/components/navigation/semi-strict-navigation-mode.ts
+++ b/src/components/navigation/semi-strict-navigation-mode.ts
@@ -1,7 +1,6 @@
 import {NavigationMode} from './navigation-mode.interface';
 import {MovingDirection} from '../util/moving-direction.enum';
 import {WizardCompletionStep} from '../util/wizard-completion-step.inferface';
-import {Injectable} from '@angular/core';
 import {WizardState} from './wizard-state.model';
 
 /**
@@ -12,7 +11,6 @@ import {WizardState} from './wizard-state.model';
  *
  * @author Marc Arndt
  */
-@Injectable()
 export class SemiStrictNavigationMode extends NavigationMode {
   /**
    * Constructor

--- a/src/components/navigation/semi-strict-navigation-mode.ts
+++ b/src/components/navigation/semi-strict-navigation-mode.ts
@@ -44,9 +44,10 @@ export class SemiStrictNavigationMode extends NavigationMode {
       .filter((step, index) => index < destinationIndex)
       .every(step => step.completed || step.optional || step.selected);
 
-    const destinationStep: WizardStep = this.wizardState.getStepAtIndex(destinationIndex);
+    // provide the destination step as a lambda in case the index doesn't exist (i.e. hasStep === false)
+    const destinationStep = () => this.wizardState.getStepAtIndex(destinationIndex);
 
-    return canExit && hasStep && (!(destinationStep instanceof WizardCompletionStep) || allNormalStepsCompleted);
+    return canExit && hasStep && (!(destinationStep() instanceof WizardCompletionStep) || allNormalStepsCompleted);
   }
 
   /**

--- a/src/components/navigation/semi-strict-navigation-mode.ts
+++ b/src/components/navigation/semi-strict-navigation-mode.ts
@@ -1,0 +1,90 @@
+import {NavigationMode} from './navigation-mode.interface';
+import {WizardComponent} from '../components/wizard.component';
+import {WizardStep} from '../util/wizard-step.interface';
+import {MovingDirection} from '../util/moving-direction.enum';
+import {WizardCompletionStep} from '../util/wizard-completion-step.inferface';
+import {Injectable} from '@angular/core';
+
+/**
+ * A [[NavigationMode]], which allows the user to navigate with some limitations.
+ * The user can only navigation to a given destination step, if:
+ * - the current step can be exited in the direction of the destination step
+ * - a completion step can only be entered, if all "normal" wizard steps have been completed
+ *
+ * @author Marc Arndt
+ */
+@Injectable()
+export class SemiStrictNavigationMode implements NavigationMode {
+  /**
+   * Constructor
+   *
+   * @param {WizardComponent} wizard The wizard, that is configured with this navigation mode
+   */
+  constructor(private wizard: WizardComponent) {
+  }
+
+  /**
+   * Checks whether the wizard can be transitioned to the given destination step.
+   * A destination wizard step can be entered if:
+   * - it exists
+   * - the current step can be exited in the direction of the destination step
+   * - all "normal" wizard steps have been completed or are optional, or the destination step isn't a completion step
+   *
+   * @param {number} destinationIndex The index of the destination wizard step
+   * @returns {boolean} True if the destination wizard step can be entered, false otherwise
+   */
+  canGoToStep(destinationIndex: number): boolean {
+    const movingDirection: MovingDirection = this.wizard.getMovingDirection(destinationIndex);
+
+    const canExit = this.wizard.canExitStep(this.wizard.currentStep, movingDirection);
+
+    const hasStep = this.wizard.hasStep(destinationIndex);
+
+    const allNormalStepsCompleted = this.wizard.wizardSteps
+      .filter((step, index) => index < destinationIndex)
+      .every(step => step.completed || step.optional);
+
+    const destinationStep: WizardStep = this.wizard.getStepAtIndex(destinationIndex);
+
+    return canExit && hasStep && (!(destinationStep instanceof WizardCompletionStep) || allNormalStepsCompleted);
+  }
+
+  /**
+   * Tries to enter the wizard step with the given destination index.
+   * When entering the destination step, the following actions are done:
+   * - the old current step is set as completed
+   * - the old current step is set as unselected
+   * - the old current step is exited
+   * - the destination step is set as selected
+   * - the destination step is entered
+   *
+   * When the destination step couldn't be entered, the following actions are done:
+   * - the current step is exited and entered in the direction `MovingDirection.Stay`
+   *
+   * @param {number} destinationIndex The index of the destination wizard step, which should be entered
+   */
+  goToStep(destinationIndex: number): void {
+    const destinationStep: WizardStep = this.wizard.getStepAtIndex(destinationIndex);
+
+    const movingDirection: MovingDirection = this.wizard.getMovingDirection(destinationIndex);
+
+    // the current step can be exited in the given direction
+    if (this.canGoToStep(destinationIndex)) {
+      // leave current step
+      this.wizard.currentStep.completed = true;
+      this.wizard.currentStep.exit(movingDirection);
+      this.wizard.currentStep.selected = false;
+
+      this.wizard.currentStepIndex = destinationIndex;
+      this.wizard.currentStep = destinationStep;
+
+      // go to next step
+      this.wizard.currentStep.enter(movingDirection);
+      this.wizard.currentStep.selected = true;
+    } else {
+      // if the current step can't be left, reenter the current step
+      this.wizard.currentStep.exit(MovingDirection.Stay);
+      this.wizard.currentStep.enter(MovingDirection.Stay);
+    }
+  }
+}

--- a/src/components/navigation/semi-strict-navigation-mode.ts
+++ b/src/components/navigation/semi-strict-navigation-mode.ts
@@ -1,5 +1,4 @@
 import {NavigationMode} from './navigation-mode.interface';
-import {WizardStep} from '../util/wizard-step.interface';
 import {MovingDirection} from '../util/moving-direction.enum';
 import {WizardCompletionStep} from '../util/wizard-completion-step.inferface';
 import {Injectable} from '@angular/core';

--- a/src/components/navigation/semi-strict-navigation-mode.ts
+++ b/src/components/navigation/semi-strict-navigation-mode.ts
@@ -65,8 +65,6 @@ export class SemiStrictNavigationMode extends NavigationMode {
    * @param {number} destinationIndex The index of the destination wizard step, which should be entered
    */
   goToStep(destinationIndex: number): void {
-    const destinationStep: WizardStep = this.wizardState.getStepAtIndex(destinationIndex);
-
     const movingDirection: MovingDirection = this.wizardState.getMovingDirection(destinationIndex);
 
     // the current step can be exited in the given direction

--- a/src/components/navigation/strict-navigation-mode.spec.ts
+++ b/src/components/navigation/strict-navigation-mode.spec.ts
@@ -63,7 +63,7 @@ describe('StrictNavigationMode', () => {
 
     wizardTest = wizardTestFixture.componentInstance;
     wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
-    navigationMode = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(NavigationMode);
+    navigationMode = wizardState.navigationMode;
   });
 
   it('should create', () => {

--- a/src/components/navigation/strict-navigation-mode.spec.ts
+++ b/src/components/navigation/strict-navigation-mode.spec.ts
@@ -24,7 +24,7 @@ class WizardTestComponent {
 }
 
 function checkWizardSteps(steps: Array<WizardStep>, selectedStepIndex: number) {
-  steps.forEach((step, index, array) => {
+  steps.forEach((step, index) => {
     // Only the selected step should be selected
     if (index === selectedStepIndex) {
       expect(step.selected).toBe(true, `the selected wizard step index ${index} is not selected`);
@@ -193,5 +193,30 @@ describe('StrictNavigationMode', () => {
     expect(wizardState.currentStep).toBe(wizardState.getStepAtIndex(0));
 
     checkWizardSteps(wizardState.wizardSteps, 0);
+  });
+
+  it('should reset the wizard correctly', () => {
+    navigationMode.goToNextStep();
+    navigationMode.goToNextStep();
+
+    expect(wizardState.currentStepIndex).toBe(2);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(true);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
+
+    navigationMode.reset();
+
+    expect(wizardState.currentStepIndex).toBe(0);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
   });
 });

--- a/src/components/navigation/strict-navigation-mode.spec.ts
+++ b/src/components/navigation/strict-navigation-mode.spec.ts
@@ -58,11 +58,11 @@ describe('StrictNavigationMode', () => {
 
   beforeEach(() => {
     wizardTestFixture = TestBed.createComponent(WizardTestComponent);
+    wizardTestFixture.detectChanges();
+
     wizardTest = wizardTestFixture.componentInstance;
     wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
     navigationMode = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(NavigationMode);
-
-    wizardTestFixture.detectChanges();
   });
 
   it('should create', () => {

--- a/src/components/navigation/strict-navigation-mode.spec.ts
+++ b/src/components/navigation/strict-navigation-mode.spec.ts
@@ -1,0 +1,194 @@
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {Component, ViewChild} from '@angular/core';
+import {By} from '@angular/platform-browser';
+import {WizardStep} from '../util/wizard-step.interface';
+import {WizardModule} from '../wizard.module';
+import {WizardState} from './wizard-state.model';
+import {WizardComponent} from '../components/wizard.component';
+import {NavigationMode} from './navigation-mode.interface';
+
+@Component({
+  selector: 'test-wizard',
+  template: `
+    <wizard>
+      <wizard-step title='Steptitle 1'>Step 1</wizard-step>
+      <wizard-step title='Steptitle 2'>Step 2</wizard-step>
+      <wizard-step title='Steptitle 3'>Step 3</wizard-step>
+    </wizard>
+  `
+})
+class WizardTestComponent {
+  @ViewChild(WizardComponent)
+  private wizard: WizardComponent;
+}
+
+function checkWizardSteps(steps: Array<WizardStep>, selectedStepIndex: number) {
+  steps.forEach((step, index, array) => {
+    // Only the selected step should be selected
+    if (index === selectedStepIndex) {
+      expect(step.selected).toBe(true, `the selected wizard step index ${index} is not selected`);
+    } else {
+      expect(step.selected).toBe(false, `the not selected wizard step index ${index} is selected`);
+    }
+
+    // All steps before the selected step need to be completed
+    if (index < selectedStepIndex) {
+      expect(step.completed).toBe(true,
+        `the wizard step ${index} is not completed while the currently selected step index is ${selectedStepIndex}`);
+    } else if (index > selectedStepIndex) {
+      expect(step.completed).toBe(false,
+        `the wizard step ${index} is completed while the currently selected step index is ${selectedStepIndex}`);
+    }
+  });
+}
+
+describe('StrictNavigationMode', () => {
+  let wizardTest: WizardTestComponent;
+  let wizardTestFixture: ComponentFixture<WizardTestComponent>;
+
+  let wizardState: WizardState;
+  let navigationMode: NavigationMode;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [WizardTestComponent],
+      imports: [WizardModule]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    wizardTestFixture = TestBed.createComponent(WizardTestComponent);
+    wizardTest = wizardTestFixture.componentInstance;
+    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    navigationMode = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(NavigationMode);
+
+    wizardTestFixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(wizardTest).toBeTruthy();
+    expect(wizardTestFixture.debugElement.query(By.css('wizard'))).toBeTruthy();
+  });
+
+  it('should return correct can go to step', () => {
+    expect(navigationMode.canGoToStep(-1)).toBe(false);
+    expect(navigationMode.canGoToStep(0)).toBe(true);
+    expect(navigationMode.canGoToStep(1)).toBe(true);
+    expect(navigationMode.canGoToStep(2)).toBe(false);
+    expect(navigationMode.canGoToStep(3)).toBe(false);
+  });
+
+  it('should return correct can go to next step', () => {
+    expect(navigationMode.canGoToNextStep()).toBe(true);
+
+    navigationMode.goToNextStep();
+
+    checkWizardSteps(wizardState.wizardSteps, 1);
+    expect(navigationMode.canGoToNextStep()).toBe(true);
+
+    navigationMode.goToNextStep();
+
+    checkWizardSteps(wizardState.wizardSteps, 2);
+    expect(navigationMode.canGoToNextStep()).toBe(false);
+
+    // should do nothing
+    navigationMode.goToNextStep();
+
+    checkWizardSteps(wizardState.wizardSteps, 2);
+  });
+
+  it('should return correct can go to previous step', () => {
+    expect(navigationMode.canGoToPreviousStep()).toBe(false);
+
+    // should do nothing
+    navigationMode.goToPreviousStep();
+
+    checkWizardSteps(wizardState.wizardSteps, 0);
+
+    navigationMode.goToNextStep();
+
+    checkWizardSteps(wizardState.wizardSteps, 1);
+    expect(navigationMode.canGoToPreviousStep()).toBe(true);
+  });
+
+  it('should go to step', () => {
+    checkWizardSteps(wizardState.wizardSteps, 0);
+
+    navigationMode.goToStep(1);
+
+    expect(wizardState.currentStepIndex).toBe(1);
+    expect(wizardState.currentStep).toBe(wizardState.getStepAtIndex(1));
+    expect(wizardState.currentStep.completed).toBe(false);
+
+    checkWizardSteps(wizardState.wizardSteps, 1);
+
+    navigationMode.goToStep(2);
+
+    expect(wizardState.currentStepIndex).toBe(2);
+    expect(wizardState.currentStep).toBe(wizardState.getStepAtIndex(2));
+    expect(wizardState.currentStep.completed).toBe(false);
+
+    checkWizardSteps(wizardState.wizardSteps, 2);
+
+    navigationMode.goToStep(0);
+
+    expect(wizardState.currentStepIndex).toBe(0);
+    expect(wizardState.currentStep).toBe(wizardState.getStepAtIndex(0));
+    expect(wizardState.currentStep.completed).toBe(true);
+
+    checkWizardSteps(wizardState.wizardSteps, 0);
+
+    navigationMode.goToStep(1);
+
+    expect(wizardState.currentStepIndex).toBe(1);
+    expect(wizardState.currentStep).toBe(wizardState.getStepAtIndex(1));
+    expect(wizardState.currentStep.completed).toBe(false);
+
+    checkWizardSteps(wizardState.wizardSteps, 1);
+
+    navigationMode.goToStep(2);
+
+    expect(wizardState.currentStepIndex).toBe(2);
+    expect(wizardState.currentStep).toBe(wizardState.getStepAtIndex(2));
+    expect(wizardState.currentStep.completed).toBe(false);
+
+    checkWizardSteps(wizardState.wizardSteps, 2);
+
+    navigationMode.goToStep(1);
+
+    expect(wizardState.currentStepIndex).toBe(1);
+    expect(wizardState.currentStep).toBe(wizardState.getStepAtIndex(1));
+    expect(wizardState.currentStep.completed).toBe(true);
+
+    checkWizardSteps(wizardState.wizardSteps, 1);
+  });
+
+  it('should go to next step', () => {
+    navigationMode.goToNextStep();
+
+    wizardTestFixture.detectChanges();
+
+    expect(wizardState.currentStepIndex).toBe(1);
+    expect(wizardState.currentStep.title).toBe('Steptitle 2');
+    expect(wizardState.currentStep.completed).toBe(false);
+
+    checkWizardSteps(wizardState.wizardSteps, 1);
+  });
+
+  it('should go to previous step', () => {
+    expect(wizardState.getStepAtIndex(0).completed).toBe(false);
+    checkWizardSteps(wizardState.wizardSteps, 0);
+
+    navigationMode.goToStep(1);
+
+    expect(wizardState.getStepAtIndex(0).completed).toBe(true);
+    checkWizardSteps(wizardState.wizardSteps, 1);
+
+    navigationMode.goToPreviousStep();
+
+    expect(wizardState.currentStepIndex).toBe(0);
+    expect(wizardState.currentStep).toBe(wizardState.getStepAtIndex(0));
+
+    checkWizardSteps(wizardState.wizardSteps, 0);
+  });
+});

--- a/src/components/navigation/strict-navigation-mode.spec.ts
+++ b/src/components/navigation/strict-navigation-mode.spec.ts
@@ -6,6 +6,7 @@ import {WizardModule} from '../wizard.module';
 import {WizardState} from './wizard-state.model';
 import {WizardComponent} from '../components/wizard.component';
 import {NavigationMode} from './navigation-mode.interface';
+import {StrictNavigationMode} from './strict-navigation-mode';
 
 @Component({
   selector: 'test-wizard',
@@ -68,6 +69,8 @@ describe('StrictNavigationMode', () => {
   it('should create', () => {
     expect(wizardTest).toBeTruthy();
     expect(wizardTestFixture.debugElement.query(By.css('wizard'))).toBeTruthy();
+    expect(navigationMode instanceof StrictNavigationMode).toBe(true,
+      'Navigation mode is not an instance of StrictNavigationMode');
   });
 
   it('should return correct can go to step', () => {

--- a/src/components/navigation/strict-navigation-mode.ts
+++ b/src/components/navigation/strict-navigation-mode.ts
@@ -1,6 +1,5 @@
 import {NavigationMode} from './navigation-mode.interface';
 import {MovingDirection} from '../util/moving-direction.enum';
-import {Injectable} from '@angular/core';
 import {WizardState} from './wizard-state.model';
 
 /**
@@ -11,7 +10,6 @@ import {WizardState} from './wizard-state.model';
  *
  * @author Marc Arndt
  */
-@Injectable()
 export class StrictNavigationMode extends NavigationMode {
   /**
    * Constructor

--- a/src/components/navigation/strict-navigation-mode.ts
+++ b/src/components/navigation/strict-navigation-mode.ts
@@ -1,6 +1,4 @@
 import {NavigationMode} from './navigation-mode.interface';
-import {WizardComponent} from '../components/wizard.component';
-import {WizardStep} from '../util/wizard-step.interface';
 import {MovingDirection} from '../util/moving-direction.enum';
 import {Injectable} from '@angular/core';
 import {WizardState} from './wizard-state.model';

--- a/src/components/navigation/strict-navigation-mode.ts
+++ b/src/components/navigation/strict-navigation-mode.ts
@@ -1,0 +1,92 @@
+import {NavigationMode} from './navigation-mode.interface';
+import {WizardComponent} from '../components/wizard.component';
+import {WizardStep} from '../util/wizard-step.interface';
+import {MovingDirection} from '../util/moving-direction.enum';
+import {Injectable} from '@angular/core';
+
+/**
+ * A [[NavigationMode]], which allows the user to navigate with strict limitations.
+ * The user can only navigation to a given destination step, if:
+ * - the current step can be exited in the direction of the destination step
+ * - all previous steps to the destination step have been completed or are optional
+ *
+ * @author Marc Arndt
+ */
+@Injectable()
+export class StrictNavigationMode implements NavigationMode {
+  /**
+   * Constructor
+   *
+   * @param {WizardComponent} wizard The wizard, that is configured with this navigation mode
+   */
+  constructor(private wizard: WizardComponent) {
+  }
+
+  /**
+   * Checks whether the wizard can be transitioned to the given destination step.
+   * A destination wizard step can be entered if:
+   * - it exists
+   * - the current step can be exited in the direction of the destination step
+   * - all previous steps to the destination step have been completed or are optional
+   *
+   * @param {number} destinationIndex The index of the destination wizard step
+   * @returns {boolean} True if the destination wizard step can be entered, false otherwise
+   */
+  canGoToStep(destinationIndex: number): boolean {
+    const movingDirection: MovingDirection = this.wizard.getMovingDirection(destinationIndex);
+
+    const canExit = this.wizard.canExitStep(this.wizard.currentStep, movingDirection);
+
+    const hasStep = this.wizard.hasStep(destinationIndex);
+
+    const allPreviousStepsComplete = this.wizard.wizardSteps
+      .filter((step, index) => index < destinationIndex && index !== this.wizard.currentStepIndex)
+      .every(step => step.completed || step.optional);
+
+    return canExit && hasStep && allPreviousStepsComplete;
+  }
+
+  /**
+   * Tries to enter the wizard step with the given destination index.
+   * When entering the destination step, the following actions are done:
+   * - the old current step is set as completed
+   * - the old current step is set as unselected
+   * - the old current step is exited
+   * - all steps between the old current step and the destination step are marked as incomplete
+   * - the destination step is set as selected
+   * - the destination step is entered
+   *
+   * When the destination step couldn't be entered, the following actions are done:
+   * - the current step is exited and entered in the direction `MovingDirection.Stay`
+   *
+   * @param {number} destinationIndex The index of the destination wizard step, which should be entered
+   */
+  goToStep(destinationIndex: number): void {
+    const destinationStep: WizardStep = this.wizard.getStepAtIndex(destinationIndex);
+
+    const movingDirection: MovingDirection = this.wizard.getMovingDirection(destinationIndex);
+
+    if (this.canGoToStep(destinationIndex)) {
+      // leave current step
+      this.wizard.currentStep.completed = true;
+      this.wizard.currentStep.exit(movingDirection);
+      this.wizard.currentStep.selected = false;
+
+      // set all steps after the destination step to incomplete
+      this.wizard.wizardSteps
+        .filter((step, index) => this.wizard.currentStepIndex > destinationIndex && index > destinationIndex)
+        .forEach(step => step.completed = false);
+
+      this.wizard.currentStepIndex = destinationIndex;
+      this.wizard.currentStep = destinationStep;
+
+      // go to next step
+      this.wizard.currentStep.enter(movingDirection);
+      this.wizard.currentStep.selected = true;
+    } else {
+      // if the current step can't be left, reenter the current step
+      this.wizard.currentStep.exit(MovingDirection.Stay);
+      this.wizard.currentStep.enter(MovingDirection.Stay);
+    }
+  }
+}

--- a/src/components/navigation/wizard-state.model.spec.ts
+++ b/src/components/navigation/wizard-state.model.spec.ts
@@ -1,0 +1,153 @@
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {Component, ViewChild} from '@angular/core';
+import {By} from '@angular/platform-browser';
+import {WizardStep} from '../util/wizard-step.interface';
+import {WizardModule} from '../wizard.module';
+import {WizardState} from './wizard-state.model';
+import {WizardComponent} from '../components/wizard.component';
+
+@Component({
+  selector: 'test-wizard',
+  template: `
+    <wizard>
+      <wizard-step title='Steptitle 1'>Step 1</wizard-step>
+      <wizard-step title='Steptitle 2'>Step 2</wizard-step>
+      <wizard-step title='Steptitle 3'>Step 3</wizard-step>
+    </wizard>
+  `
+})
+class WizardTestComponent {
+}
+
+function checkWizardSteps(steps: Array<WizardStep>, selectedStepIndex: number) {
+  steps.forEach((step, index) => {
+    // Only the selected step should be selected
+    if (index === selectedStepIndex) {
+      expect(step.selected).toBe(true, `the selected wizard step index ${index} is not selected`);
+    } else {
+      expect(step.selected).toBe(false, `the not selected wizard step index ${index} is selected`);
+    }
+
+    // All steps before the selected step need to be completed
+    if (index < selectedStepIndex) {
+      expect(step.completed).toBe(true,
+        `the wizard step ${index} is not completed while the currently selected step index is ${selectedStepIndex}`);
+    } else if (index > selectedStepIndex) {
+      expect(step.completed).toBe(false,
+        `the wizard step ${index} is completed while the currently selected step index is ${selectedStepIndex}`);
+    }
+  });
+}
+
+describe('WizardState', () => {
+  let wizardTest: WizardTestComponent;
+  let wizardTestFixture: ComponentFixture<WizardTestComponent>;
+  let wizardState: WizardState;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [WizardTestComponent],
+      imports: [WizardModule]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    wizardTestFixture = TestBed.createComponent(WizardTestComponent);
+    wizardTest = wizardTestFixture.componentInstance;
+
+    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+
+    wizardTestFixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(wizardTest).toBeTruthy();
+    expect(wizardState).toBeTruthy();
+
+    expect(wizardTestFixture.debugElement.query(By.css('wizard'))).toBeTruthy();
+  });
+
+  it('should have steps', () => {
+    expect(wizardState.wizardSteps.length).toBe(3);
+  });
+
+  it('should start at first step', () => {
+    expect(wizardState.currentStepIndex).toBe(0);
+    expect(wizardState.currentStep.title).toBe('Steptitle 1');
+
+    checkWizardSteps(wizardState.wizardSteps, 0);
+  });
+
+  it('should return correct step at index', () => {
+    expect(() => wizardState.getStepAtIndex(-1))
+      .toThrow(new Error(`Expected a known step, but got stepIndex: -1.`));
+
+    expect(wizardState.getStepAtIndex(0).title).toBe('Steptitle 1');
+    expect(wizardState.getStepAtIndex(1).title).toBe('Steptitle 2');
+    expect(wizardState.getStepAtIndex(2).title).toBe('Steptitle 3');
+
+    // Check that the first wizard step is the only selected one
+    checkWizardSteps(wizardState.wizardSteps, 0);
+
+    expect(() => wizardState.getStepAtIndex(3))
+      .toThrow(new Error(`Expected a known step, but got stepIndex: 3.`));
+  });
+
+  it('should return correct index at step', () => {
+    expect(wizardState.getIndexOfStep(wizardState.getStepAtIndex(0))).toBe(0);
+    expect(wizardState.getIndexOfStep(wizardState.getStepAtIndex(1))).toBe(1);
+    expect(wizardState.getIndexOfStep(wizardState.getStepAtIndex(2))).toBe(2);
+  });
+
+  it('should have next step', () => {
+    expect(wizardState.hasNextStep()).toBe(true);
+
+    wizardState.currentStepIndex++;
+
+    expect(wizardState.hasNextStep()).toBe(true);
+
+    wizardState.currentStepIndex++;
+
+    expect(wizardState.hasNextStep()).toBe(false);
+  });
+
+  it('should have previous step', () => {
+    expect(wizardState.hasPreviousStep()).toBe(false);
+
+    wizardState.currentStepIndex++;
+
+    expect(wizardState.hasPreviousStep()).toBe(true);
+
+    wizardState.currentStepIndex++;
+
+    expect(wizardState.hasPreviousStep()).toBe(true);
+  });
+
+  it('should be last step', () => {
+    expect(wizardState.isLastStep()).toBe(false);
+
+    wizardState.currentStepIndex++;
+
+    expect(wizardState.isLastStep()).toBe(false);
+
+    wizardState.currentStepIndex++;
+
+    expect(wizardState.isLastStep()).toBe(true);
+  });
+
+  it('should reset the wizard correctly', () => {
+    wizardState.currentStepIndex = 2;
+    wizardState.getStepAtIndex(0).completed = true;
+    wizardState.getStepAtIndex(0).selected = false;
+    wizardState.getStepAtIndex(1).completed = true;
+    wizardState.getStepAtIndex(2).selected = true;
+
+    expect(wizardState.currentStepIndex).toBe(2);
+    checkWizardSteps(wizardState.wizardSteps, 2);
+
+    wizardState.reset();
+
+    expect(wizardState.currentStepIndex).toBe(0);
+    checkWizardSteps(wizardState.wizardSteps, 0);
+  });
+});

--- a/src/components/navigation/wizard-state.model.spec.ts
+++ b/src/components/navigation/wizard-state.model.spec.ts
@@ -1,10 +1,9 @@
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {Component, ViewChild} from '@angular/core';
+import {Component} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {WizardStep} from '../util/wizard-step.interface';
 import {WizardModule} from '../wizard.module';
 import {WizardState} from './wizard-state.model';
-import {WizardComponent} from '../components/wizard.component';
 
 @Component({
   selector: 'test-wizard',
@@ -132,22 +131,6 @@ describe('WizardState', () => {
     wizardState.currentStepIndex++;
 
     expect(wizardState.isLastStep()).toBe(true);
-  });
-
-  it('should reset the wizard correctly', () => {
-    wizardState.currentStepIndex = 2;
-    wizardState.getStepAtIndex(0).completed = true;
-    wizardState.getStepAtIndex(0).selected = false;
-    wizardState.getStepAtIndex(1).completed = true;
-    wizardState.getStepAtIndex(2).selected = true;
-
-    expect(wizardState.currentStepIndex).toBe(2);
-    checkWizardSteps(wizardState.wizardSteps, 2);
-
-    wizardState.reset();
-
-    expect(wizardState.currentStepIndex).toBe(0);
-    checkWizardSteps(wizardState.wizardSteps, 0);
   });
 
   it('should return null when staying in an incorrect step', () => {

--- a/src/components/navigation/wizard-state.model.spec.ts
+++ b/src/components/navigation/wizard-state.model.spec.ts
@@ -53,11 +53,10 @@ describe('WizardState', () => {
 
   beforeEach(() => {
     wizardTestFixture = TestBed.createComponent(WizardTestComponent);
-    wizardTest = wizardTestFixture.componentInstance;
-
-    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
-
     wizardTestFixture.detectChanges();
+
+    wizardTest = wizardTestFixture.componentInstance;
+    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
   });
 
   it('should create', () => {
@@ -149,5 +148,10 @@ describe('WizardState', () => {
 
     expect(wizardState.currentStepIndex).toBe(0);
     checkWizardSteps(wizardState.wizardSteps, 0);
+  });
+
+  it('should return null when staying in an incorrect step', () => {
+    wizardState.currentStepIndex = -1;
+    expect(wizardState.currentStep).toBeNull();
   });
 });

--- a/src/components/navigation/wizard-state.model.ts
+++ b/src/components/navigation/wizard-state.model.ts
@@ -1,0 +1,181 @@
+import {Injectable, QueryList} from '@angular/core';
+import {WizardStep} from '../util/wizard-step.interface';
+import {MovingDirection} from '../util/moving-direction.enum';
+
+/**
+ * The internal model/state of a wizard.
+ * This model contains:
+ * - an array with all steps the wizard contains
+ * - the index of the step the wizard currently resides inside
+ * - information about the completeness of the wizard
+ * - some additional helper methods
+ *
+ * @author Marc Arndt
+ */
+@Injectable()
+export class WizardState {
+  /**
+   * The internal [[QueryList]] with all [[WizardStep]] objects belonging to the wizard model
+   */
+  private _wizardSteps: QueryList<WizardStep>;
+
+  /**
+   * An array representation of all wizard steps belonging to this model
+   */
+  public get wizardSteps(): Array<WizardStep> {
+    if (this._wizardSteps) {
+      return this._wizardSteps.toArray();
+    } else {
+      return [];
+    }
+  }
+
+  /**
+   * The index of the currently visible and selected step inside the wizardSteps QueryList.
+   * If this wizard contains no steps, currentStepIndex is -1
+   */
+  public currentStepIndex = -1;
+
+  /**
+   * The WizardStep object belonging to the currently visible and selected step.
+   * The currentStep is always the currently selected wizard step.
+   * The currentStep can be either completed, if it was visited earlier,
+   * or not completed, if it is visited for the first time or its state is currently out of date.
+   *
+   * If this wizard contains no steps, currentStep is null
+   */
+  public get currentStep(): WizardStep {
+    if (this.hasStep(this.currentStepIndex)) {
+      return this.wizardSteps[this.currentStepIndex];
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * The completeness of the wizard.
+   * If the wizard has been completed, i.e. all steps are either completed or optional, this value is true, otherwise it is false
+   */
+  public get completed(): boolean {
+    return this.wizardSteps.every(step => step.completed || step.optional);
+  }
+
+  /**
+   * Constructor
+   */
+  constructor() {
+  }
+
+  /**
+   * Initializes the wizard state with the given array of wizard steps.
+   * This process contains a reset of the wizard
+   *
+   * @param {QueryList<WizardStep>} wizardSteps The wizard steps
+   */
+  initialize(wizardSteps: QueryList<WizardStep>): void {
+    this._wizardSteps = wizardSteps;
+    this.reset();
+  }
+
+  /**
+   * Checks if a given index `stepIndex` is inside the range of possible wizard steps inside this wizard
+   *
+   * @param stepIndex The to be checked index of a step inside this wizard
+   * @returns {boolean} True if the given `stepIndex` is contained inside this wizard, false otherwise
+   */
+  hasStep(stepIndex: number): boolean {
+    return this.wizardSteps.length > 0 && 0 <= stepIndex && stepIndex < this.wizardSteps.length;
+  }
+
+  /**
+   * Checks if this wizard has a previous step, compared to the current step
+   *
+   * @returns {boolean} True if this wizard has a previous step before the current step
+   */
+  hasPreviousStep(): boolean {
+    return this.hasStep(this.currentStepIndex - 1);
+  }
+
+  /**
+   * Checks if this wizard has a next step, compared to the current step
+   *
+   * @returns {boolean} True if this wizard has a next step after the current step
+   */
+  hasNextStep(): boolean {
+    return this.hasStep(this.currentStepIndex + 1);
+  }
+
+  /**
+   * Checks if this wizard is currently inside its last step
+   *
+   * @returns {boolean} True if the wizard is currently inside its last step
+   */
+  isLastStep(): boolean {
+    return this.wizardSteps.length > 0 && this.currentStepIndex === this.wizardSteps.length - 1;
+  }
+
+  /**
+   * Finds the [[WizardStep]] at the given index `stepIndex`.
+   * If no [[WizardStep]] exists at the given index an Error is thrown
+   *
+   * @param stepIndex The given index
+   * @returns {undefined|WizardStep} The found [[WizardStep]] at the given index `stepIndex`
+   * @throws An `Error` is thrown, if the given index `stepIndex` doesn't exist
+   */
+  getStepAtIndex(stepIndex: number): WizardStep {
+    if (!this.hasStep(stepIndex)) {
+      throw new Error(`Expected a known step, but got stepIndex: ${stepIndex}.`);
+    }
+
+    return this.wizardSteps[stepIndex];
+  }
+
+  /**
+   * Find the index of the given [[WizardStep]] `step`.
+   * If the given [[WizardStep]] is not contained inside this wizard, `-1` is returned
+   *
+   * @param step The given [[WizardStep]]
+   * @returns {number} The found index of `step` or `-1` if the step is not included in the wizard
+   */
+  getIndexOfStep(step: WizardStep): number {
+    return this.wizardSteps.indexOf(step);
+  }
+
+  /**
+   * Calculates the correct [[MovingDirection]] value for a given `destinationStep` compared to the `currentStepIndex`.
+   *
+   * @param destinationStep The given destination step
+   * @returns {MovingDirection} The calculated [[MovingDirection]]
+   */
+  getMovingDirection(destinationStep: number): MovingDirection {
+    let movingDirection: MovingDirection;
+
+    if (destinationStep > this.currentStepIndex) {
+      movingDirection = MovingDirection.Forwards;
+    } else if (destinationStep < this.currentStepIndex) {
+      movingDirection = MovingDirection.Backwards;
+    } else {
+      movingDirection = MovingDirection.Stay;
+    }
+
+    return movingDirection;
+  }
+
+  /**
+   * Resets the state of this wizard.
+   * A reset transitions the wizard automatically to the first step and sets all steps as incomplete.
+   * In addition the whole wizard is set as incomplete
+   */
+  reset(): void {
+    // reset the step internal state
+    this.wizardSteps.forEach(step => {
+      step.completed = false;
+      step.selected = false;
+    });
+
+    // set the first step as the current step
+    this.currentStepIndex = 0;
+    this.currentStep.selected = true;
+    this.currentStep.enter(MovingDirection.Forwards);
+  }
+}

--- a/src/components/navigation/wizard-state.model.ts
+++ b/src/components/navigation/wizard-state.model.ts
@@ -75,7 +75,6 @@ export class WizardState {
    */
   initialize(wizardSteps: QueryList<WizardStep>): void {
     this._wizardSteps = wizardSteps;
-    this.reset();
   }
 
   /**
@@ -160,23 +159,5 @@ export class WizardState {
     }
 
     return movingDirection;
-  }
-
-  /**
-   * Resets the state of this wizard.
-   * A reset transitions the wizard automatically to the first step and sets all steps as incomplete.
-   * In addition the whole wizard is set as incomplete
-   */
-  reset(): void {
-    // reset the step internal state
-    this.wizardSteps.forEach(step => {
-      step.completed = false;
-      step.selected = false;
-    });
-
-    // set the first step as the current step
-    this.currentStepIndex = 0;
-    this.currentStep.selected = true;
-    this.currentStep.enter(MovingDirection.Forwards);
   }
 }

--- a/src/components/navigation/wizard-state.model.ts
+++ b/src/components/navigation/wizard-state.model.ts
@@ -23,6 +23,7 @@ export class WizardState {
    * An array representation of all wizard steps belonging to this model
    */
   public get wizardSteps(): Array<WizardStep> {
+    /* istanbul ignore else */
     if (this._wizardSteps) {
       return this._wizardSteps.toArray();
     } else {

--- a/src/components/navigation/wizard-state.model.ts
+++ b/src/components/navigation/wizard-state.model.ts
@@ -1,6 +1,8 @@
 import {Injectable, QueryList} from '@angular/core';
 import {WizardStep} from '../util/wizard-step.interface';
 import {MovingDirection} from '../util/moving-direction.enum';
+import {NavigationMode} from './navigation-mode.interface';
+import {navigationModeFactory} from './navigation-mode.provider';
 
 /**
  * The internal model/state of a wizard.
@@ -36,6 +38,8 @@ export class WizardState {
    * If this wizard contains no steps, currentStepIndex is -1
    */
   public currentStepIndex = -1;
+
+  public navigationMode: NavigationMode;
 
   /**
    * The WizardStep object belonging to the currently visible and selected step.
@@ -73,8 +77,10 @@ export class WizardState {
    *
    * @param {QueryList<WizardStep>} wizardSteps The wizard steps
    */
-  initialize(wizardSteps: QueryList<WizardStep>): void {
+  initialize(wizardSteps: QueryList<WizardStep>, navigationMode: string): void {
     this._wizardSteps = wizardSteps;
+    this.navigationMode = navigationModeFactory(navigationMode, this);
+    this.navigationMode.reset();
   }
 
   /**

--- a/src/components/util/wizard-step.interface.spec.ts
+++ b/src/components/util/wizard-step.interface.spec.ts
@@ -75,8 +75,9 @@ describe('WizardStep', () => {
 
   beforeEach(() => {
     wizardTestFixture = TestBed.createComponent(WizardTestComponent);
-    wizardTest = wizardTestFixture.componentInstance;
     wizardTestFixture.detectChanges();
+
+    wizardTest = wizardTestFixture.componentInstance;
   });
 
   it('should create an instance', () => {

--- a/src/components/util/wizard-step.interface.ts
+++ b/src/components/util/wizard-step.interface.ts
@@ -1,6 +1,7 @@
 import {MovingDirection} from './moving-direction.enum';
 import {WizardStepTitleDirective} from '../directives/wizard-step-title.directive';
 import {EventEmitter} from '@angular/core';
+import {isBoolean} from 'util';
 
 /**
  * Basic functionality every type of wizard step needs to provide
@@ -90,4 +91,24 @@ export abstract class WizardStep {
    * @param direction The direction in which the step is exited
    */
   abstract exit(direction: MovingDirection): void;
+
+  /**
+   * This method returns true, if the given step `wizardStep` can be exited and false otherwise.
+   * Because this method depends on the value `canExit`, it will throw an error, if `canExit` is neither a boolean
+   * nor a function.
+   *
+   * @param wizardStep The [[WizardStep]] to be checked
+   * @param direction The direction in which this step should be left
+   * @returns {any} True if the given step `wizardStep` can be exited in the given direction, false otherwise
+   * @throws An `Error` is thrown if `wizardStep.canExit` is neither a function nor a boolean
+   */
+  public canExitStep(direction: MovingDirection): boolean {
+    if (isBoolean(this.canExit)) {
+      return this.canExit as boolean;
+    } else if (this.canExit instanceof Function) {
+      return this.canExit(direction);
+    } else {
+      throw new Error(`Input value '${this.canExit}' is neither a boolean nor a function`);
+    }
+  }
 }

--- a/src/components/util/wizard-step.interface.ts
+++ b/src/components/util/wizard-step.interface.ts
@@ -97,7 +97,6 @@ export abstract class WizardStep {
    * Because this method depends on the value `canExit`, it will throw an error, if `canExit` is neither a boolean
    * nor a function.
    *
-   * @param wizardStep The [[WizardStep]] to be checked
    * @param direction The direction in which this step should be left
    * @returns {any} True if the given step `wizardStep` can be exited in the given direction, false otherwise
    * @throws An `Error` is thrown if `wizardStep.canExit` is neither a function nor a boolean

--- a/src/components/util/wizard-step.interface.ts
+++ b/src/components/util/wizard-step.interface.ts
@@ -57,16 +57,12 @@ export abstract class WizardStep {
   /**
    * This EventEmitter is called when the step is entered.
    * The bound method should be used to do initialization work.
-   *
-   * @type {EventEmitter<MovingDirection>}
    */
   public stepEnter: EventEmitter<MovingDirection>;
 
   /**
    * This EventEmitter is called when the step is exited.
    * The bound method can be used to do cleanup work.
-   *
-   * @type {EventEmitter<MovingDirection>}
    */
   public stepExit: EventEmitter<MovingDirection>;
 
@@ -98,7 +94,7 @@ export abstract class WizardStep {
    * nor a function.
    *
    * @param direction The direction in which this step should be left
-   * @returns {any} True if the given step `wizardStep` can be exited in the given direction, false otherwise
+   * @returns {boolean} True if the given step `wizardStep` can be exited in the given direction, false otherwise
    * @throws An `Error` is thrown if `wizardStep.canExit` is neither a function nor a boolean
    */
   public canExitStep(direction: MovingDirection): boolean {

--- a/src/components/wizard.module.ts
+++ b/src/components/wizard.module.ts
@@ -1,5 +1,5 @@
 import {CommonModule} from '@angular/common';
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {ModuleWithProviders, NgModule} from '@angular/core';
 
 import {WizardComponent} from './components/wizard.component';
 import {WizardNavigationBarComponent} from './components/wizard-navigation-bar.component';
@@ -14,7 +14,6 @@ import {WizardStepTitleDirective} from './directives/wizard-step-title.directive
 import {EnableBackLinksDirective} from './directives/enable-back-links.directive';
 import {WizardStepDirective} from './directives/wizard-step.directive';
 import {WizardCompletionStepDirective} from './directives/wizard-completion-step.directive';
-import {navigationModeProvider} from './navigation/navigation-mode.provider';
 
 /**
  * The module defining all the content inside `ng2-archwizard`

--- a/src/components/wizard.module.ts
+++ b/src/components/wizard.module.ts
@@ -14,6 +14,7 @@ import {WizardStepTitleDirective} from './directives/wizard-step-title.directive
 import {EnableBackLinksDirective} from './directives/enable-back-links.directive';
 import {WizardStepDirective} from './directives/wizard-step.directive';
 import {WizardCompletionStepDirective} from './directives/wizard-completion-step.directive';
+import {navigationModeProvider} from './navigation/navigation-mode.provider';
 
 /**
  * The module defining all the content inside `ng2-archwizard`


### PR DESCRIPTION
This PR adds navigation modes to `ng2-archwizard`, as suggested in #7.
In addition, this PR moves all state/model relevant stuff from `WizardComponent` to a new class `WizardState`.
Therefore this PR may break the compatibility of `ng2-archwizard` with previous versions, if some internal methods are used, e.g. the `reset` method.