### PR TITLE
Add canEnter input to the wizard steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,14 @@ you need to set the `navigationSymbol` input attribute of the step to `&#xf2dd;`
 <wizard-step title="Second Step" navigationSymbol="&#xf2dd;" navigationSymbolFontFamily="FontAwesome"></wizard-step>
 ```
 
+#### \[canEnter\]
+Sometimes it's required to only allow the user to enter a specific step if a certain validation method returns true.
+In such a case you can use the `[canEnter]` input of the targeted wizard step.
+This input can be either a boolean, which directly tells the wizard if the targeted step can be entered, 
+or a lambda function, taking a `MovingDirection` and returning a boolean.
+This function will then be called, with the direction in which the targeted step will be entered, whenever an operation has been performed, that leads to a change of the current step.
+It then returns true, when the step change should succeed and false otherwise.
+
 #### \[canExit\]
 If you have an additional check or validation you need to perform to decide, if the step can be exited (both to the next step and to the previous step),
 you can either pass a boolean or a function, taking a `MovingDirection` enum and returning a boolean, to the `[canExit]` attribute of the wizard step.
@@ -158,7 +166,7 @@ If only exiting one direction should be covered, you can pass a function taking 
 This function will then be called, with the direction in which the current step should be moved, whenever an operation has been performed, that leads to a change of the current step.
 It then returns true, when the step change should succeed and false otherwise.
 
-#### \(canEnter\)
+#### \(stepEnter\)
 If you need to call a function to do some initialisation work before entering a wizard step you can add a `stepEnter` attribute to the wizard step environment like this:
 
 ```html
@@ -172,7 +180,7 @@ The event emitter will call the given function with a parameter that contains th
 If the user went backwards, like from the third step to the second or first step, then `MovingDirection.Backwards` will be passed to the function. 
 If the user went forwards `MovingDirection.Forwards` will be passed to the function.
 
-#### \(canExit\)
+#### \(stepExit\)
 Similar to `stepEnter` you can add a `stepExit` attribute to the wizard step environment, if you want to call a function every time a wizard step is exited 
 either by pressing on a component with a `nextStep` or `previousStep` directive, or by a click on the navigation bar. 
 `stepExit`, like `stepEnter` can call the given function with an argument of type `MovingDirection` that signalises in which direction the step was exited.
@@ -185,6 +193,7 @@ Possible `<wizard-step>` parameters:
 | [title]                       | string                                            | null          |
 | [navigationSymbol]            | string                                            | ''            |
 | [navigationSymbolFontFamily]  | string                                            | null          |
+| [canEnter]                    | function(MovingDirection): boolean &#124; boolean | true          |
 | [canExit]                     | function(MovingDirection): boolean &#124; boolean | true          |
 | (stepEnter)                   | function(MovingDirection)                         | null          |
 | (stepExit)                    | function(MovingDirection)                         | null          |
@@ -208,6 +217,7 @@ Possible `<wizard-completion-step>` parameters:
 | [title]                       | string                                            | null          |
 | [navigationSymbol]            | string                                            | ''            |
 | [navigationSymbolFontFamily]  | string                                            | null          |
+| [canEnter]                    | function(MovingDirection): boolean &#124; boolean | true          |
 | (stepEnter)                   | function(MovingDirection)                         | null          |
 
 ### \[enableBackLinks\]
@@ -354,6 +364,7 @@ Possible `[wizardStep]` parameters:
 | [title]                       | string                                            | null          |
 | [navigationSymbol]            | string                                            | ''            |
 | [navigationSymbolFontFamily]  | string                                            | null          |
+| [canEnter]                    | function(MovingDirection): boolean &#124; boolean | true          |
 | [canExit]                     | function(MovingDirection): boolean &#124; boolean | true          |
 | (stepEnter)                   | function(MovingDirection)                         | null          |
 | (stepExit)                    | function(MovingDirection)                         | null          |
@@ -382,6 +393,7 @@ Possible `[wizardCompletionStep]` parameters:
 | [title]                       | string                                            | null          |
 | [navigationSymbol]            | string                                            | ''            |
 | [navigationSymbolFontFamily]  | string                                            | null          |
+| [canEnter]                    | function(MovingDirection): boolean &#124; boolean | true          |
 | (stepEnter)                   | function(MovingDirection)                         | null          |
 
 

--- a/src/components/components/wizard-completion-step.component.spec.ts
+++ b/src/components/components/wizard-completion-step.component.spec.ts
@@ -24,7 +24,7 @@ import {NavigationMode} from '../navigation/navigation-mode.interface';
 class WizardTestComponent {
   public isValid: any = true;
 
-  public eventLog: Array<string> = new Array<string>();
+  public eventLog: Array<string> = [];
 
   enterInto(direction: MovingDirection, destination: number): void {
     this.eventLog.push(`enter ${MovingDirection[direction]} ${destination}`);

--- a/src/components/components/wizard-completion-step.component.ts
+++ b/src/components/components/wizard-completion-step.component.ts
@@ -116,6 +116,12 @@ export class WizardCompletionStepComponent extends WizardCompletionStep {
   /**
    * @inheritDoc
    */
+  @Input()
+  public canEnter: ((direction: MovingDirection) => boolean) | boolean = true;
+
+  /**
+   * @inheritDoc
+   */
   public canExit: ((direction: MovingDirection) => boolean) | boolean = false;
 
   /**

--- a/src/components/components/wizard-step.component.ts
+++ b/src/components/components/wizard-step.component.ts
@@ -88,6 +88,12 @@ export class WizardStepComponent extends WizardStep {
    * @inheritDoc
    */
   @Input()
+  public canEnter: ((direction: MovingDirection) => boolean) | boolean = true;
+
+  /**
+   * @inheritDoc
+   */
+  @Input()
   public canExit: ((direction: MovingDirection) => boolean) | boolean = true;
 
   /**

--- a/src/components/directives/wizard-completion-step.directive.ts
+++ b/src/components/directives/wizard-completion-step.directive.ts
@@ -109,6 +109,12 @@ export class WizardCompletionStepDirective extends WizardCompletionStep {
   /**
    * @inheritDoc
    */
+  @Input()
+  public canEnter: ((direction: MovingDirection) => boolean) | boolean = true;
+
+  /**
+   * @inheritDoc
+   */
   public canExit: ((direction: MovingDirection) => boolean) | boolean = false;
 
   /**

--- a/src/components/directives/wizard-step.directive.ts
+++ b/src/components/directives/wizard-step.directive.ts
@@ -86,6 +86,12 @@ export class WizardStepDirective extends WizardStep {
    * @inheritDoc
    */
   @Input()
+  public canEnter: ((direction: MovingDirection) => boolean) | boolean = true;
+
+  /**
+   * @inheritDoc
+   */
+  @Input()
   public canExit: ((direction: MovingDirection) => boolean) | boolean = true;
 
   /**

--- a/src/components/navigation/free-navigation-mode.ts
+++ b/src/components/navigation/free-navigation-mode.ts
@@ -28,12 +28,14 @@ export class FreeNavigationMode extends NavigationMode {
    * @returns {boolean} True if the destination wizard step can be entered, false otherwise
    */
   canGoToStep(destinationIndex: number): boolean {
-    const movingDirection = this.wizardState.getMovingDirection(destinationIndex);
-
-    const canExit = this.wizardState.currentStep.canExitStep(movingDirection);
     const hasStep = this.wizardState.hasStep(destinationIndex);
 
-    return canExit && hasStep;
+    const movingDirection = this.wizardState.getMovingDirection(destinationIndex);
+
+    const canExitCurrentStep = () => this.wizardState.currentStep.canExitStep(movingDirection);
+    const canEnterDestinationStep = () => this.wizardState.getStepAtIndex(destinationIndex).canEnterStep(movingDirection);
+
+    return hasStep && canExitCurrentStep() && canEnterDestinationStep();
   }
 
   /**

--- a/src/components/navigation/semi-strict-navigation-mode.ts
+++ b/src/components/navigation/semi-strict-navigation-mode.ts
@@ -32,10 +32,12 @@ export class SemiStrictNavigationMode extends NavigationMode {
    * @returns {boolean} True if the destination wizard step can be entered, false otherwise
    */
   canGoToStep(destinationIndex: number): boolean {
+    const hasStep = this.wizardState.hasStep(destinationIndex);
+
     const movingDirection = this.wizardState.getMovingDirection(destinationIndex);
 
-    const canExit = this.wizardState.currentStep.canExitStep(movingDirection);
-    const hasStep = this.wizardState.hasStep(destinationIndex);
+    const canExitCurrentStep = () => this.wizardState.currentStep.canExitStep(movingDirection);
+    const canEnterDestinationStep = () => this.wizardState.getStepAtIndex(destinationIndex).canEnterStep(movingDirection);
 
     const allNormalStepsCompleted = this.wizardState.wizardSteps
       .filter((step, index) => index < destinationIndex)
@@ -44,7 +46,8 @@ export class SemiStrictNavigationMode extends NavigationMode {
     // provide the destination step as a lambda in case the index doesn't exist (i.e. hasStep === false)
     const destinationStep = () => this.wizardState.getStepAtIndex(destinationIndex);
 
-    return canExit && hasStep && (!(destinationStep() instanceof WizardCompletionStep) || allNormalStepsCompleted);
+    return hasStep && canExitCurrentStep() && canEnterDestinationStep() &&
+      (!(destinationStep() instanceof WizardCompletionStep) || allNormalStepsCompleted);
   }
 
   /**

--- a/src/components/navigation/strict-navigation-mode.ts
+++ b/src/components/navigation/strict-navigation-mode.ts
@@ -31,16 +31,18 @@ export class StrictNavigationMode extends NavigationMode {
    * @returns {boolean} True if the destination wizard step can be entered, false otherwise
    */
   canGoToStep(destinationIndex: number): boolean {
+    const hasStep = this.wizardState.hasStep(destinationIndex);
+
     const movingDirection = this.wizardState.getMovingDirection(destinationIndex);
 
-    const canExit = this.wizardState.currentStep.canExitStep(movingDirection);
-    const hasStep = this.wizardState.hasStep(destinationIndex);
+    const canExitCurrentStep = () => this.wizardState.currentStep.canExitStep(movingDirection);
+    const canEnterDestinationStep = () => this.wizardState.getStepAtIndex(destinationIndex).canEnterStep(movingDirection);
 
     const allPreviousStepsComplete = this.wizardState.wizardSteps
       .filter((step, index) => index < destinationIndex && index !== this.wizardState.currentStepIndex)
       .every(step => step.completed || step.optional);
 
-    return canExit && hasStep && allPreviousStepsComplete;
+    return hasStep && canExitCurrentStep() && canEnterDestinationStep() && allPreviousStepsComplete;
   }
 
   /**

--- a/src/components/util/wizard-step.interface.spec.ts
+++ b/src/components/util/wizard-step.interface.spec.ts
@@ -10,6 +10,10 @@ import {WizardModule} from '../wizard.module';
 import {WizardStep} from './wizard-step.interface';
 import {WizardCompletionStepDirective} from '../directives/wizard-completion-step.directive';
 import {WizardStepDirective} from '../directives/wizard-step.directive';
+import {WizardState} from '../navigation/wizard-state.model';
+import {NavigationMode} from '../navigation/navigation-mode.interface';
+import {By} from '@angular/platform-browser';
+import {MovingDirection} from './moving-direction.enum';
 
 @Component({
   selector: 'test-wizard',
@@ -21,7 +25,7 @@ import {WizardStepDirective} from '../directives/wizard-step.directive';
       <wizard-step #step2 title='Steptitle 2' optionalStep>
         Step 2
       </wizard-step>
-      <wizard-step #step3>
+      <wizard-step [canEnter]="canEnter" [canExit]="canExit" #step3>
         <ng-template wizardStepTitle>
           Steptitle 3
         </ng-template>
@@ -60,11 +64,18 @@ class WizardTestComponent {
 
   @ViewChild('step6', {read: WizardCompletionStepDirective})
   public step6: WizardCompletionStepDirective;
+
+  public canEnter: any = true;
+
+  public canExit: any = true;
 }
 
 describe('WizardStep', () => {
   let wizardTest: WizardTestComponent;
   let wizardTestFixture: ComponentFixture<WizardTestComponent>;
+
+  let wizardState: WizardState;
+  let navigationMode: NavigationMode;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -78,6 +89,8 @@ describe('WizardStep', () => {
     wizardTestFixture.detectChanges();
 
     wizardTest = wizardTestFixture.componentInstance;
+    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    navigationMode = wizardState.navigationMode;
   });
 
   it('should create an instance', () => {
@@ -103,5 +116,75 @@ describe('WizardStep', () => {
   it('should not be a WizardStep', () => {
     expect({stepOffset: 1} instanceof WizardStep).toBe(false);
     expect({title: 'Test title'} instanceof WizardStep).toBe(false);
+  });
+
+  it('should evaluate canEnter correctly', () => {
+    expect(navigationMode.canGoToStep(2)).toBe(true);
+
+    wizardTest.canEnter = true;
+    wizardTestFixture.detectChanges();
+
+    expect(navigationMode.canGoToStep(2)).toBe(true);
+
+    wizardTest.canEnter = false;
+    wizardTestFixture.detectChanges();
+
+    expect(navigationMode.canGoToStep(2)).toBe(false);
+
+    wizardTest.canEnter = (direction) => direction === MovingDirection.Forwards;
+    wizardTestFixture.detectChanges();
+
+    expect(navigationMode.canGoToStep(2)).toBe(true);
+
+    wizardTest.canEnter = (direction) => direction === MovingDirection.Backwards;
+    wizardTestFixture.detectChanges();
+
+    expect(navigationMode.canGoToStep(2)).toBe(false);
+
+    wizardTest.canEnter = 'malformed input';
+    wizardTestFixture.detectChanges();
+
+    expect(() => navigationMode.canGoToStep(2))
+      .toThrow(new Error(`Input value 'malformed input' is neither a boolean nor a function`));
+  });
+
+  it('should evaluate canExit correctly', () => {
+    navigationMode.goToStep(2);
+    wizardTestFixture.detectChanges();
+
+    expect(navigationMode.canGoToStep(1)).toBe(true);
+    expect(navigationMode.canGoToStep(3)).toBe(true);
+
+    wizardTest.canExit = true;
+    wizardTestFixture.detectChanges();
+
+    expect(navigationMode.canGoToStep(1)).toBe(true);
+    expect(navigationMode.canGoToStep(3)).toBe(true);
+
+    wizardTest.canExit = false;
+    wizardTestFixture.detectChanges();
+
+    expect(navigationMode.canGoToStep(1)).toBe(false);
+    expect(navigationMode.canGoToStep(3)).toBe(false);
+
+    wizardTest.canExit = (direction) => direction === MovingDirection.Forwards;
+    wizardTestFixture.detectChanges();
+
+    expect(navigationMode.canGoToStep(1)).toBe(false);
+    expect(navigationMode.canGoToStep(3)).toBe(true);
+
+    wizardTest.canExit = (direction) => direction === MovingDirection.Backwards;
+    wizardTestFixture.detectChanges();
+
+    expect(navigationMode.canGoToStep(1)).toBe(true);
+    expect(navigationMode.canGoToStep(3)).toBe(false);
+
+    wizardTest.canExit = 'malformed input';
+    wizardTestFixture.detectChanges();
+
+    expect(() => navigationMode.canGoToStep(1))
+      .toThrow(new Error(`Input value 'malformed input' is neither a boolean nor a function`));
+    expect(() => navigationMode.canGoToStep(3))
+      .toThrow(new Error(`Input value 'malformed input' is neither a boolean nor a function`));
   });
 });

--- a/src/components/util/wizard-step.interface.ts
+++ b/src/components/util/wizard-step.interface.ts
@@ -50,7 +50,12 @@ export abstract class WizardStep {
   optional: boolean;
 
   /**
-   * A function, taking a [[MovingDirection]], or boolean returning true, if the step can be exited and false otherwise.
+   * A function taking a [[MovingDirection]], or boolean returning true, if the step can be entered and false otherwise.
+   */
+  canEnter: ((direction: MovingDirection) => boolean) | boolean;
+
+  /**
+   * A function taking a [[MovingDirection]], or boolean returning true, if the step can be exited and false otherwise.
    */
   canExit: ((direction: MovingDirection) => boolean) | boolean;
 
@@ -87,6 +92,25 @@ export abstract class WizardStep {
    * @param direction The direction in which the step is exited
    */
   abstract exit(direction: MovingDirection): void;
+
+  /**
+   * This method returns true, if the given step `wizardStep` can be entered and false otherwise.
+   * Because this method depends on the value `canEnter`, it will throw an error, if `canEnter` is neither a boolean
+   * nor a function.
+   *
+   * @param direction The direction in which this step should be entered
+   * @returns {boolean} True if the given step `wizardStep` can be entered in the given direction, false otherwise
+   * @throws An `Error` is thrown if `wizardStep.canEnter` is neither a function nor a boolean
+   */
+  public canEnterStep(direction: MovingDirection): boolean {
+    if (isBoolean(this.canEnter)) {
+      return this.canEnter as boolean;
+    } else if (this.canEnter instanceof Function) {
+      return this.canEnter(direction);
+    } else {
+      throw new Error(`Input value '${this.canEnter}' is neither a boolean nor a function`);
+    }
+  }
 
   /**
    * This method returns true, if the given step `wizardStep` can be exited and false otherwise.


### PR DESCRIPTION
This PR adds a new `canEnter` input to the wizard steps.
This input is used to check if a wizard step can be entered during step transitions.