### PR TITLE
Add a way to select a given step after initialisation and reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,14 +103,20 @@ for each step of your wizard, in the navigation bar, if such a symbol has been d
    The third navigation mode is free navigation. 
    This mode let's the user navigate freely between the different steps, including the completion step, in any order he desires.
 
+#### \[defaultStepIndex\]
+Per default the wizard always starts with the first wizard step, after initialisation. The same applies for a reset, where the wizard normally resets to the first step.
+Sometimes this needs to be changed. If another default wizard step needs to be used, you can set it, by using the `[defaultStepIndex]` input of the wizard component.
+For example, to start the wizard in the second step, `defaultStepIndex="2"` can to be set.
+
 #### Parameter overview
 Possible `<wizard>` parameters:
 
-| Parameter name    | Possible Values                                                                                       | Default Value |
-| ----------------- | ----------------------------------------------------------------------------------------------------- | ------------- |
-| [navBarLocation]  | top &#124; bottom &#124; left &#124; right                                                            | top           |
-| [navBarLayout]    | small &#124; large-filled &#124; large-empty &#124; large-filled-symbols &#124; large-empty-symbols   | small         |
-| [navigationMode]  | strict &#124; semi-strict &#124; free                                                                 | strict        |
+| Parameter name     | Possible Values                                                                                       | Default Value |
+| ------------------ | ----------------------------------------------------------------------------------------------------- | ------------- |
+| [navBarLocation]   | top &#124; bottom &#124; left &#124; right                                                            | top           |
+| [navBarLayout]     | small &#124; large-filled &#124; large-empty &#124; large-filled-symbols &#124; large-empty-symbols   | small         |
+| [navigationMode]   | strict &#124; semi-strict &#124; free                                                                 | strict        |
+| [defaultStepIndex] | number                                                                                                | 0             |
 
 ### \<wizard-step\>
 The `<wizard-step></wizard-step>` environment is the wizard step environment. 
@@ -260,6 +266,12 @@ Be aware, that you can only use `[wizardStepTitle]` together with Angular, becau
 If you need to define an optional step, that doesn't need to be done to continue to the next steps, you can define an optional step 
 by adding the `optionalStep` directive to the step you want to declare as optional. 
 
+### \[selected\]
+In some cases it may be a better choice to set the default wizard step not via a static number.
+Another way to set the default wizard step is by using the `selected` directive.
+When attaching the `selected` directive to an arbitrary wizard step, it will be marked as the default wizard step,
+which is shown directly after the wizard startup.
+
 ### \[goToStep\]
 `ng2-archwizard` has three directives, that allow moving between steps.
 These directives are the `previousStep`, `nextStep` and `goToStep` directives.
@@ -395,7 +407,6 @@ Possible `[wizardCompletionStep]` parameters:
 | [navigationSymbolFontFamily]  | string                                            | null          |
 | [canEnter]                    | function(MovingDirection): boolean &#124; boolean | true          |
 | (stepEnter)                   | function(MovingDirection)                         | null          |
-
 
 ### Accessing the wizard component instance
 Sometimes it's required to access the wizard component directly. 

--- a/src/components/components/wizard.component.spec.ts
+++ b/src/components/components/wizard.component.spec.ts
@@ -3,6 +3,8 @@ import {Component, ViewChild} from '@angular/core';
 import {WizardComponent} from './wizard.component';
 import {By} from '@angular/platform-browser';
 import {WizardModule} from '../wizard.module';
+import {WizardState} from '../navigation/wizard-state.model';
+import {NavigationMode} from '../navigation/navigation-mode.interface';
 
 @Component({
   selector: 'test-wizard',
@@ -23,6 +25,9 @@ describe('WizardComponent', () => {
   let wizardTest: WizardTestComponent;
   let wizardTestFixture: ComponentFixture<WizardTestComponent>;
 
+  let wizardState: WizardState;
+  let navigationMode: NavigationMode;
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [WizardTestComponent],
@@ -35,6 +40,8 @@ describe('WizardComponent', () => {
     wizardTestFixture.detectChanges();
 
     wizardTest = wizardTestFixture.componentInstance;
+    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    navigationMode = wizardState.navigationMode;
   });
 
   it('should create', () => {
@@ -42,6 +49,11 @@ describe('WizardComponent', () => {
     expect(wizardTest.wizard).toBeTruthy();
 
     expect(wizardTestFixture.debugElement.query(By.css('wizard'))).toBeTruthy();
+    expect(wizardTest.wizard.model).toBeTruthy();
+    expect(wizardTest.wizard.navigation).toBeTruthy();
+
+    expect(wizardTest.wizard.model).toBe(wizardState);
+    expect(wizardTest.wizard.navigation).toBe(navigationMode);
   });
 
   it('should contain navigation bar at the correct position in default navBarLocation mode', () => {

--- a/src/components/components/wizard.component.ts
+++ b/src/components/components/wizard.component.ts
@@ -78,6 +78,14 @@ export class WizardComponent implements AfterContentInit {
   public navigationMode = 'strict';
 
   /**
+   * The initially selected step, represented by its index
+   *
+   * @type {number}
+   */
+  @Input()
+  public defaultStepIndex = 0;
+
+  /**
    * Returns true if this wizard uses a horizontal orientation.
    * The wizard uses a horizontal orientation, iff the navigation bar is shown at the top or bottom of this wizard
    *
@@ -118,6 +126,6 @@ export class WizardComponent implements AfterContentInit {
    * Initialization work
    */
   ngAfterContentInit(): void {
-    this.model.initialize(this.wizardSteps, this.navigationMode);
+    this.model.initialize(this.wizardSteps, this.navigationMode, this.defaultStepIndex);
   }
 }

--- a/src/components/directives/index.ts
+++ b/src/components/directives/index.ts
@@ -8,4 +8,5 @@ export {PreviousStepDirective} from './previous-step.directive';
 export {OptionalStepDirective} from './optional-step.directive';
 export {WizardStepTitleDirective} from './wizard-step-title.directive';
 export {EnableBackLinksDirective} from './enable-back-links.directive';
+export {SelectedDirective} from './selected.directive';
 

--- a/src/components/directives/selected.directive.spec.ts
+++ b/src/components/directives/selected.directive.spec.ts
@@ -1,0 +1,71 @@
+import {OptionalStepDirective} from './optional-step.directive';
+import {Component} from '@angular/core';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {WizardModule} from '../wizard.module';
+import {WizardState} from '../navigation/wizard-state.model';
+import {NavigationMode} from '../navigation/navigation-mode.interface';
+
+@Component({
+  selector: 'test-wizard',
+  template: `
+    <wizard navigationMode="free">
+      <wizard-step title='Steptitle 1'>
+        Step 1
+      </wizard-step>
+      <wizard-step title='Steptitle 2' selected>
+        Step 2
+      </wizard-step>
+      <wizard-step title='Steptitle 3'>
+        Step 3
+      </wizard-step>
+    </wizard>
+  `
+})
+class WizardTestComponent {
+}
+
+describe('SelectedDirective', () => {
+  let wizardTest: WizardTestComponent;
+  let wizardTestFixture: ComponentFixture<WizardTestComponent>;
+
+  let wizardState: WizardState;
+  let navigationMode: NavigationMode;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [WizardTestComponent],
+      imports: [WizardModule]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    wizardTestFixture = TestBed.createComponent(WizardTestComponent);
+    wizardTestFixture.detectChanges();
+
+    wizardTest = wizardTestFixture.componentInstance;
+    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    navigationMode = wizardState.navigationMode;
+  });
+
+  it('should create an instance', () => {
+    expect(wizardTestFixture.debugElement.query(By.css('wizard-step[selected]'))).toBeTruthy();
+    expect(wizardTestFixture.debugElement.queryAll(By.css('wizard-step[selected]')).length).toBe(1);
+  });
+
+  it('should set optional correctly', () => {
+    expect(wizardState.defaultStepIndex).toBe(1);
+    expect(wizardState.currentStepIndex).toBe(1);
+  });
+
+  it('should reset correctly', () => {
+    navigationMode.goToStep(0);
+
+    expect(wizardState.currentStepIndex).toBe(0);
+
+    navigationMode.reset();
+    wizardTestFixture.detectChanges();
+
+    expect(wizardState.currentStepIndex).toBe(1);
+  });
+});

--- a/src/components/directives/selected.directive.ts
+++ b/src/components/directives/selected.directive.ts
@@ -15,7 +15,7 @@ import {WizardStep} from '../util/wizard-step.interface';
  * @author Marc Arndt
  */
 @Directive({
-  selector: 'selected'
+  selector: '[selected]'
 })
 export class SelectedDirective implements OnInit {
   /**

--- a/src/components/directives/selected.directive.ts
+++ b/src/components/directives/selected.directive.ts
@@ -1,0 +1,33 @@
+import {Directive, Host, OnInit} from '@angular/core';
+import {WizardStep} from '../util/wizard-step.interface';
+
+/**
+ * The `selected` directive can be used on a [[WizardStep]] to set it as selected after the wizard initialisation or a reset.
+ *
+ * ### Syntax
+ *
+ * ```html
+ * <wizard-step title="Step title" selected>
+ *     ...
+ * </wizard-step>
+ * ```
+ *
+ * @author Marc Arndt
+ */
+@Directive({
+  selector: 'selected'
+})
+export class SelectedDirective implements OnInit {
+  /**
+   * Constructor
+   * @param wizardStep The wizard step, which should be selected by default
+   */
+  constructor(@Host() private wizardStep: WizardStep) { }
+
+  /**
+   * Initialization work
+   */
+  ngOnInit(): void {
+    this.wizardStep.defaultSelected = true;
+  }
+}

--- a/src/components/navigation/free-navigation-mode.spec.ts
+++ b/src/components/navigation/free-navigation-mode.spec.ts
@@ -265,5 +265,29 @@ describe('FreeNavigationMode', () => {
     expect(wizardState.getStepAtIndex(2).selected).toBe(false);
     expect(wizardState.getStepAtIndex(2).completed).toBe(false);
     expect(wizardState.completed).toBe(false);
+
+    wizardState.defaultStepIndex = -1;
+    expect(() => navigationMode.reset()).toThrow(new Error(`The wizard doesn't contain a step with index -1`));
+
+    expect(wizardState.currentStepIndex).toBe(0);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
+
+    wizardState.defaultStepIndex = 2;
+    navigationMode.reset();
+
+    expect(wizardState.currentStepIndex).toBe(2);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
   });
 });

--- a/src/components/navigation/free-navigation-mode.ts
+++ b/src/components/navigation/free-navigation-mode.ts
@@ -84,6 +84,11 @@ export class FreeNavigationMode extends NavigationMode {
    * In addition the whole wizard is set as incomplete
    */
   reset(): void {
+    // the wizard doesn't contain a step with the default step index
+    if (!this.wizardState.hasStep(this.wizardState.defaultStepIndex)) {
+      throw new Error(`The wizard doesn't contain a step with index ${this.wizardState.defaultStepIndex}`);
+    }
+
     // reset the step internal state
     this.wizardState.wizardSteps.forEach(step => {
       step.completed = false;

--- a/src/components/navigation/free-navigation-mode.ts
+++ b/src/components/navigation/free-navigation-mode.ts
@@ -77,4 +77,22 @@ export class FreeNavigationMode extends NavigationMode {
   isNavigable(destinationIndex: number): boolean {
     return true;
   }
+
+  /**
+   * Resets the state of this wizard.
+   * A reset transitions the wizard automatically to the first step and sets all steps as incomplete.
+   * In addition the whole wizard is set as incomplete
+   */
+  reset(): void {
+    // reset the step internal state
+    this.wizardState.wizardSteps.forEach(step => {
+      step.completed = false;
+      step.selected = false;
+    });
+
+    // set the first step as the current step
+    this.wizardState.currentStepIndex = this.wizardState.defaultStepIndex;
+    this.wizardState.currentStep.selected = true;
+    this.wizardState.currentStep.enter(MovingDirection.Forwards);
+  }
 }

--- a/src/components/navigation/navigation-mode.interface.ts
+++ b/src/components/navigation/navigation-mode.interface.ts
@@ -36,6 +36,13 @@ export abstract class NavigationMode {
   abstract isNavigable(destinationIndex: number): boolean;
 
   /**
+   * Resets the state of this wizard.
+   * A reset transitions the wizard automatically to the first step and sets all steps as incomplete.
+   * In addition the whole wizard is set as incomplete
+   */
+  abstract reset(): void;
+
+  /**
    * Tries to transition the wizard to the previous step from the `currentStep`
    */
   goToPreviousStep(): void {
@@ -73,23 +80,5 @@ export abstract class NavigationMode {
     const nextStepIndex = this.wizardState.currentStepIndex + 1;
 
     return this.wizardState.hasStep(nextStepIndex) && this.canGoToStep(nextStepIndex);
-  }
-
-  /**
-   * Resets the state of this wizard.
-   * A reset transitions the wizard automatically to the first step and sets all steps as incomplete.
-   * In addition the whole wizard is set as incomplete
-   */
-  reset(): void {
-    // reset the step internal state
-    this.wizardState.wizardSteps.forEach(step => {
-      step.completed = false;
-      step.selected = false;
-    });
-
-    // set the first step as the current step
-    this.wizardState.currentStepIndex = 0;
-    this.wizardState.currentStep.selected = true;
-    this.wizardState.currentStep.enter(MovingDirection.Forwards);
   }
 }

--- a/src/components/navigation/navigation-mode.interface.ts
+++ b/src/components/navigation/navigation-mode.interface.ts
@@ -1,5 +1,4 @@
 import {WizardState} from './wizard-state.model';
-import {MovingDirection} from '../util/moving-direction.enum';
 
 /**
  * An interface describing the basic functionality, which must be provided by a navigation mode.

--- a/src/components/navigation/semi-strict-navigation-mode.spec.ts
+++ b/src/components/navigation/semi-strict-navigation-mode.spec.ts
@@ -265,5 +265,41 @@ describe('SemiStrictNavigationMode', () => {
     expect(wizardState.getStepAtIndex(2).selected).toBe(false);
     expect(wizardState.getStepAtIndex(2).completed).toBe(false);
     expect(wizardState.completed).toBe(false);
+
+    wizardState.defaultStepIndex = -1;
+    expect(() => navigationMode.reset()).toThrow(new Error(`The wizard doesn't contain a step with index -1`));
+
+    expect(wizardState.currentStepIndex).toBe(0);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
+
+    wizardState.defaultStepIndex = 2;
+    expect(() => navigationMode.reset()).toThrow(new Error(`The default step index 2 references a completion step`));
+
+    expect(wizardState.currentStepIndex).toBe(0);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
+
+    wizardState.defaultStepIndex = 1;
+    navigationMode.reset();
+
+    expect(wizardState.currentStepIndex).toBe(1);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
   });
 });

--- a/src/components/navigation/semi-strict-navigation-mode.ts
+++ b/src/components/navigation/semi-strict-navigation-mode.ts
@@ -97,27 +97,24 @@ export class SemiStrictNavigationMode extends NavigationMode {
    * @inheritDoc
    */
   reset(): void {
-    // reset the step internal state
-    this.wizardState.wizardSteps.forEach(step => {
-      step.completed = false;
-      step.selected = false;
-    });
+    // the wizard doesn't contain a step with the default step index
+    if (!this.wizardState.hasStep(this.wizardState.defaultStepIndex)) {
+      throw new Error(`The wizard doesn't contain a step with index ${this.wizardState.defaultStepIndex}`);
+    }
 
-    // the default step is a completion step
-    const defaultCompletionStep = this.wizardState.getStepAtIndex(this.wizardState.defaultStepIndex) instanceof WizardCompletionStep;
+    // the default step is a completion step and the wizard contains more than one step
+    const defaultCompletionStep = this.wizardState.getStepAtIndex(this.wizardState.defaultStepIndex) instanceof WizardCompletionStep &&
+      this.wizardState.wizardSteps.length !== 1;
 
     if (defaultCompletionStep) {
       throw new Error(`The default step index ${this.wizardState.defaultStepIndex} references a completion step`);
     }
 
-    // at least one step is before the default step, that is not optional
-    const illegalDefaultStep = this.wizardState.wizardSteps
-      .filter((step, index) => index < this.wizardState.defaultStepIndex)
-      .some(step => !step.optional);
-
-    if (illegalDefaultStep) {
-      throw new Error(`The default step index ${this.wizardState.defaultStepIndex} is located after a non optional step`);
-    }
+    // reset the step internal state
+    this.wizardState.wizardSteps.forEach(step => {
+      step.completed = false;
+      step.selected = false;
+    });
 
     // set the first step as the current step
     this.wizardState.currentStepIndex = this.wizardState.defaultStepIndex;

--- a/src/components/navigation/strict-navigation-mode.spec.ts
+++ b/src/components/navigation/strict-navigation-mode.spec.ts
@@ -12,7 +12,7 @@ import {StrictNavigationMode} from './strict-navigation-mode';
   selector: 'test-wizard',
   template: `
     <wizard>
-      <wizard-step title='Steptitle 1'>Step 1</wizard-step>
+      <wizard-step title='Steptitle 1' optionalStep>Step 1</wizard-step>
       <wizard-step title='Steptitle 2'>Step 2</wizard-step>
       <wizard-step title='Steptitle 3'>Step 3</wizard-step>
     </wizard>
@@ -214,6 +214,42 @@ describe('StrictNavigationMode', () => {
     expect(wizardState.getStepAtIndex(0).selected).toBe(true);
     expect(wizardState.getStepAtIndex(0).completed).toBe(false);
     expect(wizardState.getStepAtIndex(1).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
+
+    wizardState.defaultStepIndex = -1;
+    expect(() => navigationMode.reset()).toThrow(new Error(`The wizard doesn't contain a step with index -1`));
+
+    expect(wizardState.currentStepIndex).toBe(0);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
+
+    wizardState.defaultStepIndex = 1;
+    navigationMode.reset();
+
+    expect(wizardState.currentStepIndex).toBe(1);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(true);
+    expect(wizardState.getStepAtIndex(1).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(2).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(2).completed).toBe(false);
+    expect(wizardState.completed).toBe(false);
+
+    wizardState.defaultStepIndex = 2;
+    expect(() => navigationMode.reset()).toThrow(new Error(`The default step index 2 is located after a non optional step`));
+
+    expect(wizardState.currentStepIndex).toBe(1);
+    expect(wizardState.getStepAtIndex(0).selected).toBe(false);
+    expect(wizardState.getStepAtIndex(0).completed).toBe(false);
+    expect(wizardState.getStepAtIndex(1).selected).toBe(true);
     expect(wizardState.getStepAtIndex(1).completed).toBe(false);
     expect(wizardState.getStepAtIndex(2).selected).toBe(false);
     expect(wizardState.getStepAtIndex(2).completed).toBe(false);

--- a/src/components/navigation/strict-navigation-mode.ts
+++ b/src/components/navigation/strict-navigation-mode.ts
@@ -89,4 +89,31 @@ export class StrictNavigationMode extends NavigationMode {
   isNavigable(destinationIndex: number): boolean {
     return false;
   }
+
+  /**
+   * Resets the state of this wizard.
+   * A reset transitions the wizard automatically to the first step and sets all steps as incomplete.
+   * In addition the whole wizard is set as incomplete
+   */
+  reset(): void {
+    // reset the step internal state
+    this.wizardState.wizardSteps.forEach(step => {
+      step.completed = false;
+      step.selected = false;
+    });
+
+    // at least one step is before the default step, that is not optional
+    const illegalDefaultStep = this.wizardState.wizardSteps
+      .filter((step, index) => index < this.wizardState.defaultStepIndex)
+      .some(step => !step.optional);
+
+    if (illegalDefaultStep) {
+      throw new Error(`The default step index ${this.wizardState.defaultStepIndex} is located after a non optional step`);
+    }
+
+    // set the first step as the current step
+    this.wizardState.currentStepIndex = this.wizardState.defaultStepIndex;
+    this.wizardState.currentStep.selected = true;
+    this.wizardState.currentStep.enter(MovingDirection.Forwards);
+  }
 }

--- a/src/components/navigation/strict-navigation-mode.ts
+++ b/src/components/navigation/strict-navigation-mode.ts
@@ -96,11 +96,10 @@ export class StrictNavigationMode extends NavigationMode {
    * In addition the whole wizard is set as incomplete
    */
   reset(): void {
-    // reset the step internal state
-    this.wizardState.wizardSteps.forEach(step => {
-      step.completed = false;
-      step.selected = false;
-    });
+    // the wizard doesn't contain a step with the default step index
+    if (!this.wizardState.hasStep(this.wizardState.defaultStepIndex)) {
+      throw new Error(`The wizard doesn't contain a step with index ${this.wizardState.defaultStepIndex}`);
+    }
 
     // at least one step is before the default step, that is not optional
     const illegalDefaultStep = this.wizardState.wizardSteps
@@ -110,6 +109,12 @@ export class StrictNavigationMode extends NavigationMode {
     if (illegalDefaultStep) {
       throw new Error(`The default step index ${this.wizardState.defaultStepIndex} is located after a non optional step`);
     }
+
+    // reset the step internal state
+    this.wizardState.wizardSteps.forEach(step => {
+      step.completed = false;
+      step.selected = false;
+    });
 
     // set the first step as the current step
     this.wizardState.currentStepIndex = this.wizardState.defaultStepIndex;

--- a/src/components/navigation/wizard-state.model.ts
+++ b/src/components/navigation/wizard-state.model.ts
@@ -39,6 +39,16 @@ export class WizardState {
   }
 
   /**
+   * Sets the initial default step.
+   * Beware: This initial default is only used if no wizard step has been enhanced with the `selected` directive
+   *
+   * @param defaultStepIndex The new default wizard step index
+   */
+  public set defaultStepIndex(defaultStepIndex) {
+    this._defaultStepIndex = defaultStepIndex;
+  }
+
+  /**
    * The initial step index.
    * This value can be either:
    * - the index of a wizard step with a `selected` directive, or

--- a/src/components/navigation/wizard-state.model.ts
+++ b/src/components/navigation/wizard-state.model.ts
@@ -22,6 +22,11 @@ export class WizardState {
   private _wizardSteps: QueryList<WizardStep>;
 
   /**
+   * The initial step index, as taken from the [[WizardComponent]]
+   */
+  private _defaultStepIndex = 0;
+
+  /**
    * An array representation of all wizard steps belonging to this model
    */
   public get wizardSteps(): Array<WizardStep> {
@@ -34,11 +39,30 @@ export class WizardState {
   }
 
   /**
+   * The initial step index.
+   * This value can be either:
+   * - the index of a wizard step with a `selected` directive, or
+   * - the default step index, set in the [[WizardComponent]]
+   */
+  public get defaultStepIndex(): number {
+    const foundDefaultStep = this.wizardSteps.find(step => step.defaultSelected);
+
+    if (foundDefaultStep) {
+      return this.getIndexOfStep(foundDefaultStep);
+    } else {
+      return this._defaultStepIndex;
+    }
+  };
+
+  /**
    * The index of the currently visible and selected step inside the wizardSteps QueryList.
    * If this wizard contains no steps, currentStepIndex is -1
    */
   public currentStepIndex = -1;
 
+  /**
+   * The navigation mode used to navigate inside the wizard
+   */
   public navigationMode: NavigationMode;
 
   /**
@@ -77,8 +101,9 @@ export class WizardState {
    *
    * @param {QueryList<WizardStep>} wizardSteps The wizard steps
    */
-  initialize(wizardSteps: QueryList<WizardStep>, navigationMode: string): void {
+  initialize(wizardSteps: QueryList<WizardStep>, navigationMode: string, defaultStepIndex: number): void {
     this._wizardSteps = wizardSteps;
+    this._defaultStepIndex = defaultStepIndex;
     this.navigationMode = navigationModeFactory(navigationMode, this);
     this.navigationMode.reset();
   }

--- a/src/components/navigation/wizard-state.model.ts
+++ b/src/components/navigation/wizard-state.model.ts
@@ -110,6 +110,8 @@ export class WizardState {
    * This process contains a reset of the wizard
    *
    * @param {QueryList<WizardStep>} wizardSteps The wizard steps
+   * @param {string} navigationMode The name of the navigation mode to be set
+   * @param {string} defaultStepIndex The default step index, to be used during the initialisation
    */
   initialize(wizardSteps: QueryList<WizardStep>, navigationMode: string, defaultStepIndex: number): void {
     this._wizardSteps = wizardSteps;

--- a/src/components/util/wizard-step.interface.ts
+++ b/src/components/util/wizard-step.interface.ts
@@ -45,6 +45,11 @@ export abstract class WizardStep {
   selected: boolean;
 
   /**
+   * A boolean describing, if the wizard step should be selected by default, i.e. after the wizard has been initialized as the initial step
+   */
+  defaultSelected: boolean;
+
+  /**
    * A boolean describing if the wizard step is an optional step
    */
   optional: boolean;

--- a/src/components/wizard.module.ts
+++ b/src/components/wizard.module.ts
@@ -14,6 +14,7 @@ import {WizardStepTitleDirective} from './directives/wizard-step-title.directive
 import {EnableBackLinksDirective} from './directives/enable-back-links.directive';
 import {WizardStepDirective} from './directives/wizard-step.directive';
 import {WizardCompletionStepDirective} from './directives/wizard-completion-step.directive';
+import {SelectedDirective} from './directives/selected.directive';
 
 /**
  * The module defining all the content inside `ng2-archwizard`
@@ -33,7 +34,8 @@ import {WizardCompletionStepDirective} from './directives/wizard-completion-step
     WizardStepTitleDirective,
     EnableBackLinksDirective,
     WizardStepDirective,
-    WizardCompletionStepDirective
+    WizardCompletionStepDirective,
+    SelectedDirective
   ],
   imports: [
     CommonModule
@@ -50,7 +52,8 @@ import {WizardCompletionStepDirective} from './directives/wizard-completion-step
     WizardStepTitleDirective,
     EnableBackLinksDirective,
     WizardStepDirective,
-    WizardCompletionStepDirective
+    WizardCompletionStepDirective,
+    SelectedDirective
   ]
 })
 export class WizardModule {


### PR DESCRIPTION
This PR targets #19.
It introduces a `defaultStepIndex` input for the `WizardComponent`, which takes an optional index of the initial wizard step, which is shown after startup.
In addition it introduces a new `selected` directive, which can be added to a wizard step to indicate, that it is meant as the default step.