### PR TITLE
Remove duplicate can exit calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,9 +307,18 @@ that contains to which step a click on the element should change the current ste
 This can be useful if your step transitions depend on some application dependent logic, that changes depending on the user input.
 Here again it's important to use `[]` around the `goToStep` directive to tell angular that the argument is to be interpreted as javascript.  
 
+#### \(preFinalize\)
+Sometimes it's required to bind an event emitter to a specific element, which can perform a step transition. 
+Such an event emitter can be bound to the `(preFinalize)` output of the element, which contains the `goToStep` directive.
+This event emitter is then called, directly before the wizard transitions to the given step.
+
+#### \(postFinalize\)
+Alternatively you can also bind an event emitter to `(postFinalize)`, 
+which is executed directly after the wizard transitions to the given step.
+
 #### \(finalize\)
-If you want to call a function only after pressing on a element with a `goToStep` directive, you can do this, 
-by adding the function to the `finalize` attribute of the element with the `goToStep` directive.
+In case you don't really care when the finalization event emitter is called, you can also bind it simply to `(finalize)`. 
+`finalize` is a synonym for `preFinalize`. 
 
 #### Parameter overview
 Possible parameters:
@@ -317,6 +326,8 @@ Possible parameters:
 | Parameter name    | Possible Values                                           | Default Value |
 | ----------------- | --------------------------------------------------------- | ------------- |
 | [goToStep]        | WizardStep &#124; StepOffset &#124; number &#124; string  | null          |
+| (preFinalize)     | function()                                                | null          |
+| (postFinalize)    | function()                                                | null          |
 | (finalize)        | function()                                                | null          |
 
 ### \[nextStep\]
@@ -328,16 +339,18 @@ This listener will automatically change the currently selected wizard step to th
 ```
 
 #### \(finalize\)
-Like the `goToStep` directive the `nextStep` directive provides a `finalize` output, that is called every time
+Like the `goToStep` directive the `nextStep` directive provides a `preFinalize`, `postFinalize` and `finalize` output, which are called every time
 the current step is successfully exited, by clicking on the element containing the `nextStep` directive.
 
-In the given code snipped above, a click on the button with the text `Next Step`, leads to a call of the function `finalizeStep` every time, the button has been pressed.
+In the given code snipped above, a click on the button with the text `Next Step`, leads to a call of the `finalize` functions every time, the button has been pressed.
 
 #### Parameter overview
 Possible parameters:
 
 | Parameter name    | Possible Values                             | Default Value |
 | ----------------- | ------------------------------------------- | ------------- |
+| (preFinalize)     | function()                                  | null          |
+| (postFinalize)    | function()                                  | null          |
 | (finalize)        | function()                                  | null          |
 
 ### \[previousStep\]
@@ -349,7 +362,7 @@ This listener will automatically change the currently selected wizard step to th
 ```
 
 #### \(finalize\)
-Like both the `goToStep` and `nextStep` directives the `previousStep` directives too provides a `finalize` output, that is called every time
+Like both the `goToStep` and `nextStep` directives the `previousStep` directives too provides a `preFinalize`, `postFinalize` and `finalize` output, which are called every time
 the current step is successfully exited, by clicking on the element containing the `previousStep` directive.
 
 #### Parameter overview
@@ -357,6 +370,8 @@ Possible parameters:
 
 | Parameter name    | Possible Values                             | Default Value |
 | ----------------- | ------------------------------------------- | ------------- |
+| (preFinalize)     | function()                                  | null          |
+| (postFinalize)    | function()                                  | null          |
 | (finalize)        | function()                                  | null          |
 
 ### \[wizardStep\]

--- a/src/directives/go-to-step.directive.spec.ts
+++ b/src/directives/go-to-step.directive.spec.ts
@@ -15,9 +15,9 @@ import {NavigationMode} from '../navigation/navigation-mode.interface';
     <wizard>
       <wizard-step stepTitle='Steptitle 1' [canExit]="canExit">
         Step 1
-        <button type="button" goToStep="0" (finalize)="finalizeStep(1)">Stay at this step</button>
-        <button type="button" [goToStep]="goToSecondStep" (finalize)="finalizeStep(1)">Go to second step</button>
-        <button type="button" [goToStep]="{stepOffset: 2}" (finalize)="finalizeStep(1)">Go to third step</button>
+        <button type="button" goToStep="0" (preFinalize)="finalizeStep(1)">Stay at this step</button>
+        <button type="button" [goToStep]="goToSecondStep" (preFinalize)="finalizeStep(1)">Go to second step</button>
+        <button type="button" [goToStep]="{stepOffset: 2}" (preFinalize)="finalizeStep(1)">Go to third step</button>
       </wizard-step>
       <wizard-step stepTitle='Steptitle 2' optionalStep>
         Step 2
@@ -26,7 +26,7 @@ import {NavigationMode} from '../navigation/navigation-mode.interface';
       </wizard-step>
       <wizard-step stepTitle='Steptitle 3'>
         Step 3
-        <button type="button" [goToStep]="{stepOffset: -2}" (finalize)="finalizeStep(3)">Go to first step</button>
+        <button type="button" [goToStep]="{stepOffset: -2}" (postFinalize)="finalizeStep(3)">Go to first step</button>
       </wizard-step>
     </wizard>
   `

--- a/src/directives/go-to-step.directive.ts
+++ b/src/directives/go-to-step.directive.ts
@@ -40,13 +40,38 @@ import {NavigationMode} from '../navigation/navigation-mode.interface';
 })
 export class GoToStepDirective {
   /**
-   * An EventEmitter to be called when this directive is used to exit the current step.
-   * This EventEmitter can be used to do cleanup work
+   * This [[EventEmitter]] is called directly before the current step is exited during a transition through a component with this directive.
    *
    * @type {EventEmitter}
    */
   @Output()
-  public finalize = new EventEmitter();
+  public preFinalize: EventEmitter<void> = new EventEmitter();
+
+  /**
+   * This [[EventEmitter]] is called directly after the current step is exited during a transition through a component with this directive.
+   *
+   * @type {EventEmitter}
+   */
+  @Output()
+  public postFinalize: EventEmitter<void> = new EventEmitter();
+
+  /**
+   * A convenience name for `preFinalize`
+   *
+   * @param {EventEmitter<void>} emitter The [[EventEmitter]] to be set
+   */
+  @Output()
+  public set finalize(emitter: EventEmitter<void>) {
+    /* istanbul ignore next */
+    this.preFinalize = emitter;
+  }
+
+  /**
+   * A convenience field for `preFinalize`
+   */
+  public get finalize(): EventEmitter<void> {
+    return this.preFinalize;
+  }
 
   /**
    * The destination step, to which the wizard should navigate, after the component, having this directive has been activated.
@@ -103,10 +128,6 @@ export class GoToStepDirective {
    * After this method is called the wizard will try to transition to the `destinationStep`
    */
   @HostListener('click', ['$event']) onClick(): void {
-    if (this.navigationMode.canGoToStep(this.destinationStep)) {
-      this.finalize.emit();
-
-      this.navigationMode.goToStep(this.destinationStep);
-    }
+    this.navigationMode.goToStep(this.destinationStep, this.preFinalize, this.postFinalize);
   }
 }

--- a/src/directives/next-step.directive.spec.ts
+++ b/src/directives/next-step.directive.spec.ts
@@ -13,10 +13,11 @@ import {NavigationMode} from '../navigation/navigation-mode.interface';
       <wizard-step stepTitle='Steptitle 1'>
         Step 1
         <button type="button" nextStep (finalize)="finalizeStep(1)">Go to second step</button>
+        <button type="button" nextStep (postFinalize)="finalizeStep(1)">Go to second step</button>
       </wizard-step>
       <wizard-step stepTitle='Steptitle 2'>
         Step 2
-        <button type="button" nextStep (finalize)="finalizeStep(2)">Go to third step</button>
+        <button type="button" nextStep (postFinalize)="finalizeStep(2)">Go to first step</button>
       </wizard-step>
     </wizard>
   `
@@ -58,7 +59,7 @@ describe('NextStepDirective', () => {
     expect(wizardTestFixture.debugElement.query(
       By.css('wizard-step[stepTitle="Steptitle 2"] > button[nextStep]'))).toBeTruthy();
     expect(wizardTestFixture.debugElement.queryAll(
-      By.css('wizard-step > button[nextStep]')).length).toBe(2);
+      By.directive(NextStepDirective)).length).toBe(3);
   });
 
   it('should move correctly to the next step', () => {
@@ -80,22 +81,41 @@ describe('NextStepDirective', () => {
     expect(wizardState.currentStepIndex).toBe(1);
   });
 
-  it('should move call finalize correctly when going the next step', () => {
-    const firstStepButton = wizardTestFixture.debugElement.query(
-      By.css('wizard-step[stepTitle="Steptitle 1"] > button[nextStep]')).nativeElement;
-    const secondStepButton = wizardTestFixture.debugElement.query(
-      By.css('wizard-step[stepTitle="Steptitle 2"] > button[nextStep]')).nativeElement;
+  it('should call finalize correctly when going the next step', () => {
+    const firstStepButtons = wizardTestFixture.debugElement.queryAll(
+      By.css('wizard-step[stepTitle="Steptitle 1"] > button[nextStep]'));
 
     expect(wizardTest.eventLog).toEqual([]);
 
     // go to second step
-    firstStepButton.click();
+    firstStepButtons[0].nativeElement.click();
 
     expect(wizardTest.eventLog).toEqual(['finalize 1']);
+  });
+
+  it('should call postFinalize correctly when going the next step', () => {
+    const firstStepButtons = wizardTestFixture.debugElement.queryAll(
+      By.css('wizard-step[stepTitle="Steptitle 1"] > button[nextStep]'));
+
+    expect(wizardTest.eventLog).toEqual([]);
+
+    // go to second step
+    firstStepButtons[1].nativeElement.click();
+
+    expect(wizardTest.eventLog).toEqual(['finalize 1']);
+  });
+
+  it('shouldn\'t call finalize when going to an nonexistent step', () => {
+    const secondStepButton = wizardTestFixture.debugElement.query(
+      By.css('wizard-step[stepTitle="Steptitle 2"] > button[nextStep]')).nativeElement;
+
+    navigationMode.goToStep(1);
+
+    expect(wizardTest.eventLog).toEqual([]);
 
     // don't go to third step because it doesn't exist
     secondStepButton.click();
 
-    expect(wizardTest.eventLog).toEqual(['finalize 1']);
+    expect(wizardTest.eventLog).toEqual([]);
   });
 });

--- a/src/directives/next-step.directive.ts
+++ b/src/directives/next-step.directive.ts
@@ -18,13 +18,38 @@ import {WizardState} from '../navigation/wizard-state.model';
 })
 export class NextStepDirective {
   /**
-   * An EventEmitter to be called when this directive is used to exit the current step.
-   * This EventEmitter can be used to do cleanup work
+   * This [[EventEmitter]] is called directly before the current step is exited during a transition through a component with this directive.
    *
    * @type {EventEmitter}
    */
   @Output()
-  public finalize = new EventEmitter();
+  public preFinalize: EventEmitter<void> = new EventEmitter();
+
+  /**
+   * This [[EventEmitter]] is called directly after the current step is exited during a transition through a component with this directive.
+   *
+   * @type {EventEmitter}
+   */
+  @Output()
+  public postFinalize: EventEmitter<void> = new EventEmitter();
+
+  /**
+   * A convenience name for `preFinalize`
+   *
+   * @param {EventEmitter<void>} emitter The [[EventEmitter]] to be set
+   */
+  @Output()
+  public set finalize(emitter: EventEmitter<void>) {
+    /* istanbul ignore next */
+    this.preFinalize = emitter;
+  }
+
+  /**
+   * A convenience field for `preFinalize`
+   */
+  public get finalize(): EventEmitter<void> {
+    return this.preFinalize;
+  }
 
   /**
    * The navigation mode
@@ -47,10 +72,6 @@ export class NextStepDirective {
    * After this method is called the wizard will try to transition to the next step
    */
   @HostListener('click', ['$event']) onClick(): void {
-    if (this.navigationMode.canGoToNextStep()) {
-      this.finalize.emit();
-
-      this.navigationMode.goToNextStep();
-    }
+    this.navigationMode.goToNextStep(this.preFinalize, this.postFinalize);
   }
 }

--- a/src/directives/previous-step.directive.ts
+++ b/src/directives/previous-step.directive.ts
@@ -1,4 +1,4 @@
-import {Directive, HostListener} from '@angular/core';
+import {Directive, EventEmitter, HostListener, Output} from '@angular/core';
 import {NavigationMode} from '../navigation/navigation-mode.interface';
 import {WizardState} from '../navigation/wizard-state.model';
 
@@ -18,6 +18,40 @@ import {WizardState} from '../navigation/wizard-state.model';
   selector: '[previousStep]'
 })
 export class PreviousStepDirective {
+  /**
+   * This [[EventEmitter]] is called directly before the current step is exited during a transition through a component with this directive.
+   *
+   * @type {EventEmitter}
+   */
+  @Output()
+  public preFinalize: EventEmitter<void> = new EventEmitter();
+
+  /**
+   * This [[EventEmitter]] is called directly after the current step is exited during a transition through a component with this directive.
+   *
+   * @type {EventEmitter}
+   */
+  @Output()
+  public postFinalize: EventEmitter<void> = new EventEmitter();
+
+  /**
+   * A convenience field for `preFinalize`
+   *
+   * @param {EventEmitter<void>} emitter The [[EventEmitter]] to be set
+   */
+  @Output()
+  public set finalize(emitter: EventEmitter<void>) {
+    /* istanbul ignore next */
+    this.preFinalize = emitter;
+  }
+
+  /**
+   * A convenience field for `preFinalize`
+   */
+  public get finalize(): EventEmitter<void> {
+    return this.preFinalize;
+  }
+
   /**
    * The navigation mode
    *
@@ -39,8 +73,6 @@ export class PreviousStepDirective {
    * After this method is called the wizard will try to transition to the previous step
    */
   @HostListener('click', ['$event']) onClick(): void {
-    if (this.navigationMode.canGoToPreviousStep()) {
-      this.navigationMode.goToPreviousStep();
-    }
+    this.navigationMode.goToPreviousStep(this.preFinalize, this.postFinalize);
   }
 }

--- a/src/navigation/free-navigation-mode.spec.ts
+++ b/src/navigation/free-navigation-mode.spec.ts
@@ -60,34 +60,6 @@ describe('FreeNavigationMode', () => {
     expect(navigationMode.canGoToStep(3)).toBe(false);
   });
 
-  it('should return correct can go to next step', () => {
-    expect(navigationMode.canGoToNextStep()).toBe(true);
-
-    navigationMode.goToNextStep();
-
-    expect(navigationMode.canGoToNextStep()).toBe(true);
-
-    navigationMode.goToNextStep();
-
-    expect(navigationMode.canGoToNextStep()).toBe(false);
-  });
-
-  it('should return correct can go to previous step', () => {
-    expect(navigationMode.canGoToPreviousStep()).toBe(false);
-
-    // should do nothing
-    navigationMode.goToPreviousStep();
-
-    expect(wizardState.currentStepIndex).toBe(0);
-    expect(wizardState.currentStep.selected).toBe(true);
-    expect(wizardState.currentStep.completed).toBe(false);
-    expect(navigationMode.canGoToPreviousStep()).toBe(false);
-
-    navigationMode.goToNextStep();
-
-    expect(navigationMode.canGoToPreviousStep()).toBe(true);
-  });
-
   it('should go to step', () => {
     expect(wizardState.currentStepIndex).toBe(0);
     expect(wizardState.getStepAtIndex(0).selected).toBe(true);

--- a/src/navigation/free-navigation-mode.ts
+++ b/src/navigation/free-navigation-mode.ts
@@ -1,6 +1,7 @@
 import {NavigationMode} from './navigation-mode.interface';
 import {MovingDirection} from '../util/moving-direction.enum';
 import {WizardState} from './wizard-state.model';
+import {EventEmitter} from '@angular/core';
 
 /**
  * A [[NavigationMode]], which allows the user to navigate without any limitations,
@@ -51,12 +52,19 @@ export class FreeNavigationMode extends NavigationMode {
    * - the current step is exited and entered in the direction `MovingDirection.Stay`
    *
    * @param {number} destinationIndex The index of the destination wizard step, which should be entered
+   * @param {EventEmitter<void>} preFinalize An event emitter, to be called before the step has been transitioned
+   * @param {EventEmitter<void>} postFinalize An event emitter, to be called after the step has been transitioned
    */
-  goToStep(destinationIndex: number): void {
+  goToStep(destinationIndex: number, preFinalize?: EventEmitter<void>, postFinalize?: EventEmitter<void>): void {
     const movingDirection: MovingDirection = this.wizardState.getMovingDirection(destinationIndex);
 
     // the current step can be exited in the given direction
     if (this.canGoToStep(destinationIndex)) {
+      /* istanbul ignore if */
+      if (preFinalize) {
+        preFinalize.emit();
+      }
+
       // leave current step
       this.wizardState.currentStep.completed = true;
       this.wizardState.currentStep.exit(movingDirection);
@@ -67,6 +75,11 @@ export class FreeNavigationMode extends NavigationMode {
       // go to next step
       this.wizardState.currentStep.enter(movingDirection);
       this.wizardState.currentStep.selected = true;
+
+      /* istanbul ignore if */
+      if (postFinalize) {
+        postFinalize.emit();
+      }
     } else {
       // if the current step can't be left, reenter the current step
       this.wizardState.currentStep.exit(MovingDirection.Stay);

--- a/src/navigation/navigation-mode.interface.ts
+++ b/src/navigation/navigation-mode.interface.ts
@@ -1,4 +1,5 @@
 import {WizardState} from './wizard-state.model';
+import {EventEmitter} from '@angular/core';
 
 /**
  * An interface describing the basic functionality, which must be provided by a navigation mode.
@@ -23,8 +24,10 @@ export abstract class NavigationMode {
    * If this is not possible, the current wizard step should be exited and then reentered with `MovingDirection.Stay`
    *
    * @param {number} destinationIndex The index of the destination step
+   * @param {EventEmitter<void>} preFinalize An event emitter, to be called before the step has been transitioned
+   * @param {EventEmitter<void>} postFinalize An event emitter, to be called after the step has been transitioned
    */
-  abstract goToStep(destinationIndex: number): void;
+  abstract goToStep(destinationIndex: number, preFinalize?: EventEmitter<void>, postFinalize?: EventEmitter<void>): void;
 
   /**
    * Checks, whether the wizard step, located at the given index, is can be navigated to
@@ -44,40 +47,18 @@ export abstract class NavigationMode {
   /**
    * Tries to transition the wizard to the previous step from the `currentStep`
    */
-  goToPreviousStep(): void {
+  goToPreviousStep(preFinalize?: EventEmitter<void>, postFinalize?: EventEmitter<void>): void {
     if (this.wizardState.hasPreviousStep()) {
-      this.goToStep(this.wizardState.currentStepIndex - 1);
+      this.goToStep(this.wizardState.currentStepIndex - 1, preFinalize, postFinalize);
     }
   }
 
   /**
    * Tries to transition the wizard to the next step from the `currentStep`
    */
-  goToNextStep(): void {
+  goToNextStep(preFinalize?: EventEmitter<void>, postFinalize?: EventEmitter<void>): void {
     if (this.wizardState.hasNextStep()) {
-      this.goToStep(this.wizardState.currentStepIndex + 1);
+      this.goToStep(this.wizardState.currentStepIndex + 1, preFinalize, postFinalize);
     }
-  }
-
-  /**
-   * Checks if it's possible to transition to the previous step from the `currentStep`
-   *
-   * @returns {boolean} True if it's possible to transition to the previous step, false otherwise
-   */
-  canGoToPreviousStep(): boolean {
-    const previousStepIndex = this.wizardState.currentStepIndex - 1;
-
-    return this.wizardState.hasStep(previousStepIndex) && this.canGoToStep(previousStepIndex);
-  }
-
-  /**
-   * Checks if it's possible to transition to the next step from the `currentStep`
-   *
-   * @returns {boolean} True if it's possible to transition to the next step, false otherwise
-   */
-  canGoToNextStep(): boolean {
-    const nextStepIndex = this.wizardState.currentStepIndex + 1;
-
-    return this.wizardState.hasStep(nextStepIndex) && this.canGoToStep(nextStepIndex);
   }
 }

--- a/src/navigation/semi-strict-navigation-mode.spec.ts
+++ b/src/navigation/semi-strict-navigation-mode.spec.ts
@@ -60,34 +60,6 @@ describe('SemiStrictNavigationMode', () => {
     expect(navigationMode.canGoToStep(3)).toBe(false);
   });
 
-  it('should return correct can go to next step', () => {
-    expect(navigationMode.canGoToNextStep()).toBe(true);
-
-    navigationMode.goToNextStep();
-
-    expect(navigationMode.canGoToNextStep()).toBe(true);
-
-    navigationMode.goToNextStep();
-
-    expect(navigationMode.canGoToNextStep()).toBe(false);
-  });
-
-  it('should return correct can go to previous step', () => {
-    expect(navigationMode.canGoToPreviousStep()).toBe(false);
-
-    // should do nothing
-    navigationMode.goToPreviousStep();
-
-    expect(wizardState.currentStepIndex).toBe(0);
-    expect(wizardState.currentStep.selected).toBe(true);
-    expect(wizardState.currentStep.completed).toBe(false);
-    expect(navigationMode.canGoToPreviousStep()).toBe(false);
-
-    navigationMode.goToNextStep();
-
-    expect(navigationMode.canGoToPreviousStep()).toBe(true);
-  });
-
   it('should go to step', () => {
     expect(wizardState.currentStepIndex).toBe(0);
     expect(wizardState.getStepAtIndex(0).selected).toBe(true);

--- a/src/navigation/strict-navigation-mode.spec.ts
+++ b/src/navigation/strict-navigation-mode.spec.ts
@@ -81,39 +81,6 @@ describe('StrictNavigationMode', () => {
     expect(navigationMode.canGoToStep(3)).toBe(false);
   });
 
-  it('should return correct can go to next step', () => {
-    expect(navigationMode.canGoToNextStep()).toBe(true);
-
-    navigationMode.goToNextStep();
-
-    checkWizardSteps(wizardState.wizardSteps, 1);
-    expect(navigationMode.canGoToNextStep()).toBe(true);
-
-    navigationMode.goToNextStep();
-
-    checkWizardSteps(wizardState.wizardSteps, 2);
-    expect(navigationMode.canGoToNextStep()).toBe(false);
-
-    // should do nothing
-    navigationMode.goToNextStep();
-
-    checkWizardSteps(wizardState.wizardSteps, 2);
-  });
-
-  it('should return correct can go to previous step', () => {
-    expect(navigationMode.canGoToPreviousStep()).toBe(false);
-
-    // should do nothing
-    navigationMode.goToPreviousStep();
-
-    checkWizardSteps(wizardState.wizardSteps, 0);
-
-    navigationMode.goToNextStep();
-
-    checkWizardSteps(wizardState.wizardSteps, 1);
-    expect(navigationMode.canGoToPreviousStep()).toBe(true);
-  });
-
   it('should go to step', () => {
     checkWizardSteps(wizardState.wizardSteps, 0);
 

--- a/src/navigation/strict-navigation-mode.ts
+++ b/src/navigation/strict-navigation-mode.ts
@@ -1,6 +1,7 @@
 import {NavigationMode} from './navigation-mode.interface';
 import {MovingDirection} from '../util/moving-direction.enum';
 import {WizardState} from './wizard-state.model';
+import {EventEmitter} from '@angular/core';
 
 /**
  * A [[NavigationMode]], which allows the user to navigate with strict limitations.
@@ -59,11 +60,18 @@ export class StrictNavigationMode extends NavigationMode {
    * - the current step is exited and entered in the direction `MovingDirection.Stay`
    *
    * @param {number} destinationIndex The index of the destination wizard step, which should be entered
+   * @param {EventEmitter<void>} preFinalize An event emitter, to be called before the step has been transitioned
+   * @param {EventEmitter<void>} postFinalize An event emitter, to be called after the step has been transitioned
    */
-  goToStep(destinationIndex: number): void {
+  goToStep(destinationIndex: number, preFinalize?: EventEmitter<void>, postFinalize?: EventEmitter<void>): void {
     const movingDirection: MovingDirection = this.wizardState.getMovingDirection(destinationIndex);
 
     if (this.canGoToStep(destinationIndex)) {
+      /* istanbul ignore if */
+      if (preFinalize) {
+        preFinalize.emit();
+      }
+
       // leave current step
       this.wizardState.currentStep.completed = true;
       this.wizardState.currentStep.exit(movingDirection);
@@ -79,6 +87,11 @@ export class StrictNavigationMode extends NavigationMode {
       // go to next step
       this.wizardState.currentStep.enter(movingDirection);
       this.wizardState.currentStep.selected = true;
+
+      /* istanbul ignore if */
+      if (postFinalize) {
+        postFinalize.emit();
+      }
     } else {
       // if the current step can't be left, reenter the current step
       this.wizardState.currentStep.exit(MovingDirection.Stay);

--- a/src/util/wizard-step.interface.spec.ts
+++ b/src/util/wizard-step.interface.spec.ts
@@ -1,15 +1,10 @@
 /**
  * Created by marc on 29.06.17.
  */
-import {Component, ViewChild} from '@angular/core';
-import {WizardComponent} from '../components/wizard.component';
-import {ComponentFixture, async, TestBed} from '@angular/core/testing';
-import {WizardStepComponent} from '../components/wizard-step.component';
-import {WizardCompletionStepComponent} from '../components/wizard-completion-step.component';
+import {Component} from '@angular/core';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {WizardModule} from '../wizard.module';
 import {WizardStep} from './wizard-step.interface';
-import {WizardCompletionStepDirective} from '../directives/wizard-completion-step.directive';
-import {WizardStepDirective} from '../directives/wizard-step.directive';
 import {WizardState} from '../navigation/wizard-state.model';
 import {NavigationMode} from '../navigation/navigation-mode.interface';
 import {By} from '@angular/platform-browser';

--- a/src/util/wizard-step.interface.ts
+++ b/src/util/wizard-step.interface.ts
@@ -96,6 +96,25 @@ export abstract class WizardStep {
   }
 
   /**
+   * This method returns true, if this wizard step can be transitioned with a given direction.
+   * Transitioned in this case means either entered or exited, depending on the given `condition` parameter.
+   *
+   * @param condition A condition variable, deciding if the step can be transitioned
+   * @param direction The direction in which this step should be transitioned
+   * @returns {boolean} True if this step can transitioned in the given direction
+   * @throws An `Error` is thrown if `condition` is neither a function nor a boolean
+   */
+  private static canTransitionStep(condition: ((direction: MovingDirection) => boolean) | boolean, direction: MovingDirection): boolean {
+    if (isBoolean(condition)) {
+      return condition as boolean;
+    } else if (condition instanceof Function) {
+      return condition(direction);
+    } else {
+      throw new Error(`Input value '${condition}' is neither a boolean nor a function`);
+    }
+  }
+
+  /**
    * A function called when the step is entered
    *
    * @param direction The direction in which the step is entered
@@ -114,40 +133,28 @@ export abstract class WizardStep {
   }
 
   /**
-   * This method returns true, if the given step `wizardStep` can be entered and false otherwise.
+   * This method returns true, if this wizard step can be entered from the given direction.
    * Because this method depends on the value `canEnter`, it will throw an error, if `canEnter` is neither a boolean
    * nor a function.
    *
    * @param direction The direction in which this step should be entered
-   * @returns {boolean} True if the given step `wizardStep` can be entered in the given direction, false otherwise
-   * @throws An `Error` is thrown if `wizardStep.canEnter` is neither a function nor a boolean
+   * @returns {boolean} True if the step can be entered in the given direction, false otherwise
+   * @throws An `Error` is thrown if `anEnter` is neither a function nor a boolean
    */
   public canEnterStep(direction: MovingDirection): boolean {
-    if (isBoolean(this.canEnter)) {
-      return this.canEnter as boolean;
-    } else if (this.canEnter instanceof Function) {
-      return this.canEnter(direction);
-    } else {
-      throw new Error(`Input value '${this.canEnter}' is neither a boolean nor a function`);
-    }
+    return WizardStep.canTransitionStep(this.canEnter, direction);
   }
 
   /**
-   * This method returns true, if the given step `wizardStep` can be exited and false otherwise.
+   * This method returns true, if this wizard step can be exited into given direction.
    * Because this method depends on the value `canExit`, it will throw an error, if `canExit` is neither a boolean
    * nor a function.
    *
    * @param direction The direction in which this step should be left
-   * @returns {boolean} True if the given step `wizardStep` can be exited in the given direction, false otherwise
-   * @throws An `Error` is thrown if `wizardStep.canExit` is neither a function nor a boolean
+   * @returns {boolean} True if the step can be exited in the given direction, false otherwise
+   * @throws An `Error` is thrown if `canExit` is neither a function nor a boolean
    */
   public canExitStep(direction: MovingDirection): boolean {
-    if (isBoolean(this.canExit)) {
-      return this.canExit as boolean;
-    } else if (this.canExit instanceof Function) {
-      return this.canExit(direction);
-    } else {
-      throw new Error(`Input value '${this.canExit}' is neither a boolean nor a function`);
-    }
+    return WizardStep.canTransitionStep(this.canExit, direction);
   }
 }


### PR DESCRIPTION
This PR closes #33.
In addition this PR introduces some new outputs for the `goToStep`, `nextStep` and `previousStep` directives, namely:
- `preFinalize`: this event emitter is called directly before the wizard is transitioned
- `postFinalize`: this event emitter is called directly after the wizard is transitioned
- `finalize` this event emitter still exists and functions as a forwarder to `preFinalize`

This PR also removes the now unused methods `canGoToNextStep` and `canGoToPreviousStep`.