### PR TITLE
Allow promises in canExit and canEnter inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,18 +164,17 @@ you need to set the `navigationSymbol` input attribute of the step to `&#xf2dd;`
 Sometimes it's required to only allow the user to enter a specific step if a certain validation method returns true.
 In such a case you can use the `[canEnter]` input of the targeted wizard step.
 This input can be either a boolean, which directly tells the wizard if the targeted step can be entered, 
-or a lambda function, taking a `MovingDirection` and returning a boolean.
+or a lambda function, taking a `MovingDirection` and returning a `boolean` or a `Promise<boolean>`.
 This function will then be called, with the direction in which the targeted step will be entered, whenever an operation has been performed, that leads to a change of the current step.
 It then returns true, when the step change should succeed and false otherwise.
 
 #### \[canExit\]
 If you have an additional check or validation you need to perform to decide, if the step can be exited (both to the next step and to the previous step),
-you can either pass a boolean or a function, taking a `MovingDirection` enum and returning a boolean, to the `[canExit]` attribute of the wizard step.
-This boolean or function is taken in account when an operation has been performed, that leads to a change of the current step.
+you can either pass a boolean or a function, taking a `MovingDirection` enum and returning a boolean or a `Promise<boolean>`, to the `[canExit]` attribute of the wizard step.
+This boolean, or function, is taken into account, when an operation has been performed, which leads to a transition of the current step.
 If `[canExit]` has been bound to a boolean, it needs to be true to leave the step either in both a forwards and backwards direction.
-If only exiting one direction should be covered, you can pass a function taking `MovingDirection` and returning a boolean to `[canExit]`.
-This function will then be called, with the direction in which the current step should be moved, whenever an operation has been performed, that leads to a change of the current step.
-It then returns true, when the step change should succeed and false otherwise.
+If only exiting in one direction should be covered, you can pass a function, taking a `MovingDirection` and returning a boolean, to `[canExit]`.
+This function will then be called whenever an operation has been performed, that leads to a change of the current step.
 
 #### \(stepEnter\)
 If you need to call a function to do some initialisation work before entering a wizard step you can add a `stepEnter` attribute to the wizard step environment like this:
@@ -199,15 +198,15 @@ either by pressing on a component with a `nextStep` or `previousStep` directive,
 #### Parameter overview
 Possible `<wizard-step>` parameters:
 
-| Parameter name                | Possible Values                                   | Default Value |
-| ----------------------------- | ------------------------------------------------- | ------------- |
-| [stepTitle]                   | string                                            | null          |
-| [navigationSymbol]            | string                                            | ''            |
-| [navigationSymbolFontFamily]  | string                                            | null          |
-| [canEnter]                    | function(MovingDirection): boolean &#124; boolean | true          |
-| [canExit]                     | function(MovingDirection): boolean &#124; boolean | true          |
-| (stepEnter)                   | function(MovingDirection)                         | null          |
-| (stepExit)                    | function(MovingDirection)                         | null          |
+| Parameter name                | Possible Values                                                                                      | Default Value |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------- | ------------- |
+| [stepTitle]                   | string                                                                                               | null          |
+| [navigationSymbol]            | string                                                                                               | ''            |
+| [navigationSymbolFontFamily]  | string                                                                                               | null          |
+| [canEnter]                    | function(MovingDirection): boolean &#124; function(MovingDirection): Promise<boolean> &#124; boolean | true          |
+| [canExit]                     | function(MovingDirection): boolean &#124; boolean                                                    | true          |
+| (stepEnter)                   | function(MovingDirection)                                                                            | null          |
+| (stepExit)                    | function(MovingDirection)                                                                            | null          |
 
 ### \<wizard-completion-step\>
 In addition to the "normal" step component `<wizard-step>` it's also possible to define an optional `<wizard-completion-step>`.
@@ -223,13 +222,13 @@ because it can't be exited.
 #### Parameter overview
 Possible `<wizard-completion-step>` parameters:
 
-| Parameter name                | Possible Values                                   | Default Value |
-| ----------------------------- | ------------------------------------------------- | ------------- |
-| [stepTitle]                   | string                                            | null          |
-| [navigationSymbol]            | string                                            | ''            |
-| [navigationSymbolFontFamily]  | string                                            | null          |
-| [canEnter]                    | function(MovingDirection): boolean &#124; boolean | true          |
-| (stepEnter)                   | function(MovingDirection)                         | null          |
+| Parameter name                | Possible Values                                                                                      | Default Value |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------- | ------------- |
+| [stepTitle]                   | string                                                                                               | null          |
+| [navigationSymbol]            | string                                                                                               | ''            |
+| [navigationSymbolFontFamily]  | string                                                                                               | null          |
+| [canEnter]                    | function(MovingDirection): boolean &#124; function(MovingDirection): Promise<boolean> &#124; boolean | true          |
+| (stepEnter)                   | function(MovingDirection)                                                                            | null          |
 
 ### \[enableBackLinks\]
 In some cases it may be required that the user is able to leave an entered `wizard-completion-step`.
@@ -393,15 +392,15 @@ This can be done by defining adding the `[wizardStep]` directive to the componen
 #### Parameter overview
 Possible `[wizardStep]` parameters:
 
-| Parameter name                | Possible Values                                   | Default Value |
-| ----------------------------- | ------------------------------------------------- | ------------- |
-| [stepTitle]                   | string                                            | null          |
-| [navigationSymbol]            | string                                            | ''            |
-| [navigationSymbolFontFamily]  | string                                            | null          |
-| [canEnter]                    | function(MovingDirection): boolean &#124; boolean | true          |
-| [canExit]                     | function(MovingDirection): boolean &#124; boolean | true          |
-| (stepEnter)                   | function(MovingDirection)                         | null          |
-| (stepExit)                    | function(MovingDirection)                         | null          |
+| Parameter name                | Possible Values                                                                                      | Default Value |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------- | ------------- |
+| [stepTitle]                   | string                                                                                               | null          |
+| [navigationSymbol]            | string                                                                                               | ''            |
+| [navigationSymbolFontFamily]  | string                                                                                               | null          |
+| [canEnter]                    | function(MovingDirection): boolean &#124; function(MovingDirection): Promise<boolean> &#124; boolean | true          |
+| [canExit]                     | function(MovingDirection): boolean &#124; boolean                                                    | true          |
+| (stepEnter)                   | function(MovingDirection)                                                                            | null          |
+| (stepExit)                    | function(MovingDirection)                                                                            | null          |
 
 ### \[wizardCompletionStep\]
 In addition to the possibility of defining a normal wizard step in a custom component, 
@@ -422,13 +421,13 @@ that contains the wizard completion step.
 #### Parameter overview
 Possible `[wizardCompletionStep]` parameters:
 
-| Parameter name                | Possible Values                                   | Default Value |
-| ----------------------------- | ------------------------------------------------- | ------------- |
-| [stepTitle]                   | string                                            | null          |
-| [navigationSymbol]            | string                                            | ''            |
-| [navigationSymbolFontFamily]  | string                                            | null          |
-| [canEnter]                    | function(MovingDirection): boolean &#124; boolean | true          |
-| (stepEnter)                   | function(MovingDirection)                         | null          |
+| Parameter name                | Possible Values                                                                                      | Default Value |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------- | ------------- |
+| [stepTitle]                   | string                                                                                               | null          |
+| [navigationSymbol]            | string                                                                                               | ''            |
+| [navigationSymbolFontFamily]  | string                                                                                               | null          |
+| [canEnter]                    | function(MovingDirection): boolean &#124; function(MovingDirection): Promise<boolean> &#124; boolean | true          |
+| (stepEnter)                   | function(MovingDirection)                                                                            | null          |
 
 ### Accessing the wizard component instance
 Sometimes it's required to access the wizard component directly. 

--- a/src/components/wizard-navigation-bar.component.spec.ts
+++ b/src/components/wizard-navigation-bar.component.spec.ts
@@ -1,4 +1,4 @@
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {Component, ViewChild} from '@angular/core';
 import {WizardNavigationBarComponent} from './wizard-navigation-bar.component';
 import {WizardComponent} from './wizard.component';
@@ -88,11 +88,12 @@ describe('WizardNavigationBarComponent', () => {
     expect(navigableLi.length).toBe(0);
   });
 
-  it('should show the second step correctly', () => {
+  it('should show the second step correctly', fakeAsync(() => {
     const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
 
     // go to second step
     navigationMode.goToNextStep();
+    tick();
     wizardTestFixture.detectChanges();
 
     const allLi = navBar.queryAll(By.css('li'));
@@ -124,15 +125,19 @@ describe('WizardNavigationBarComponent', () => {
 
     expect(navigableLi.length).toBe(1);
     expect(navigableLi[0]).toBe(allLi[0]);
-  });
+  }));
 
-  it('should show the third step correctly', () => {
+  it('should show the third step correctly', fakeAsync(() => {
     const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
 
     // go to second step
     navigationMode.goToNextStep();
+    tick();
+    wizardTestFixture.detectChanges();
+
     // go to third step
     navigationMode.goToNextStep();
+    tick();
     wizardTestFixture.detectChanges();
 
     const allLi = navBar.queryAll(By.css('li'));
@@ -165,13 +170,14 @@ describe('WizardNavigationBarComponent', () => {
     expect(doneLi.length).toBe(2);
     expect(navigableLi[0]).toBe(allLi[0]);
     expect(navigableLi[1]).toBe(allLi[1]);
-  });
+  }));
 
-  it('should show the third step correctly, after jump from first to third step', () => {
+  it('should show the third step correctly, after jump from first to third step', fakeAsync(() => {
     const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
 
     // go to third step and jump over the optional second step
     navigationMode.goToStep(2);
+    tick();
     wizardTestFixture.detectChanges();
 
     const allLi = navBar.queryAll(By.css('li'));
@@ -204,15 +210,19 @@ describe('WizardNavigationBarComponent', () => {
     expect(navigableLi.length).toBe(2);
     expect(navigableLi[0]).toBe(allLi[0]);
     expect(navigableLi[1]).toBe(allLi[1]);
-  });
+  }));
 
-  it('should show the first step correctly, after going back from the second step to the first step', () => {
+  it('should show the first step correctly, after going back from the second step to the first step', fakeAsync(() => {
     const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
 
     // go to second step
     navigationMode.goToNextStep();
+    tick();
+    wizardTestFixture.detectChanges();
+
     // go back to first step
     navigationMode.goToPreviousStep();
+    tick();
     wizardTestFixture.detectChanges();
 
     const allLi = navBar.queryAll(By.css('li'));
@@ -243,16 +253,20 @@ describe('WizardNavigationBarComponent', () => {
     expect(defaultLi[0]).toBe(allLi[2]);
 
     expect(navigableLi.length).toBe(0);
-  });
+  }));
 
   it('should show the first step correctly, after first jumping from the first to the third step ' +
-    'and then back from the third step to the first step', () => {
+    'and then back from the third step to the first step', fakeAsync(() => {
     const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
 
     // go to third step, by jumping over the optional step
     navigationMode.goToStep(2);
+    tick();
+    wizardTestFixture.detectChanges();
+
     // go back to first step
     navigationMode.goToStep(0);
+    tick();
     wizardTestFixture.detectChanges();
 
     const allLi = navBar.queryAll(By.css('li'));
@@ -283,16 +297,20 @@ describe('WizardNavigationBarComponent', () => {
     expect(defaultLi[0]).toBe(allLi[2]);
 
     expect(navigableLi.length).toBe(0);
-  });
+  }));
 
   it('should show the second step correctly, after first jumping from the first to the third step ' +
-    'and then back from the third step to the second step', () => {
+    'and then back from the third step to the second step', fakeAsync(() => {
     const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
 
     // go to third step, by jumping over the optional step
     navigationMode.goToStep(2);
+    tick();
+    wizardTestFixture.detectChanges();
+
     // go back to second step
     navigationMode.goToPreviousStep();
+    tick();
     wizardTestFixture.detectChanges();
 
     const allLi = navBar.queryAll(By.css('li'));
@@ -324,14 +342,16 @@ describe('WizardNavigationBarComponent', () => {
 
     expect(navigableLi.length).toBe(1);
     expect(navigableLi[0]).toBe(allLi[0]);
-  });
+  }));
 
-  it('should disable navigation through the navigation bar correctly', () => {
+  it('should disable navigation through the navigation bar correctly', fakeAsync(() => {
     const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
 
     wizardState.disableNavigationBar = true;
+
     // go to third step and jump over the optional second step
     navigationMode.goToStep(2);
+    tick();
     wizardTestFixture.detectChanges();
 
     const allLi = navBar.queryAll(By.css('li'));
@@ -362,55 +382,67 @@ describe('WizardNavigationBarComponent', () => {
     expect(defaultLi.length).toBe(0);
 
     expect(navigableLi.length).toBe(0);
-  });
+  }));
 
-  it('should move back to the first step from the second step, after clicking on the corresponding link', () => {
+  it('should move back to the first step from the second step, after clicking on the corresponding link', fakeAsync(() => {
     const goToFirstStepLink = wizardTestFixture.debugElement.query(By.css('li:nth-child(1) a')).nativeElement;
 
     expect(wizardState.currentStepIndex).toBe(0);
 
     // go to the second step
     navigationMode.goToNextStep();
+    tick();
+    wizardTestFixture.detectChanges();
+
     expect(wizardState.currentStepIndex).toBe(1);
 
     // go back to the first step
     goToFirstStepLink.click();
+    tick();
     wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(0);
-  });
+  }));
 
-  it('should move back to the first step from the third step, after clicking on the corresponding link', () => {
+  it('should move back to the first step from the third step, after clicking on the corresponding link', fakeAsync(() => {
     const goToFirstStepLink = wizardTestFixture.debugElement.query(By.css('li:nth-child(1) a')).nativeElement;
 
     expect(wizardState.currentStepIndex).toBe(0);
 
     // go to the second step
     navigationMode.goToStep(2);
+    tick();
+    wizardTestFixture.detectChanges();
+
     expect(wizardState.currentStepIndex).toBe(2);
 
     // go back to the first step
     goToFirstStepLink.click();
+    tick();
     wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(0);
-  });
+  }));
 
-  it('should move back to the second step from the third step, after clicking on the corresponding link', () => {
+  it('should move back to the second step from the third step, after clicking on the corresponding link', fakeAsync(() => {
     const goToSecondStepLink = wizardTestFixture.debugElement.query(By.css('li:nth-child(2) a')).nativeElement;
 
     expect(wizardState.currentStepIndex).toBe(0);
 
     // go to the second step
     navigationMode.goToStep(2);
+    tick();
+    wizardTestFixture.detectChanges();
+
     expect(wizardState.currentStepIndex).toBe(2);
 
     // go back to the first step
     goToSecondStepLink.click();
+    tick();
     wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(1);
-  });
+  }));
 
   it('should not move to the second step from the first step, after clicking on the corresponding link', () => {
     const goToFirstStepLink = wizardTestFixture.debugElement.query(By.css('li:nth-child(1)'));

--- a/src/directives/enable-back-links.directive.spec.ts
+++ b/src/directives/enable-back-links.directive.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Created by marc on 30.06.17.
  */
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {Component} from '@angular/core';
 import {MovingDirection} from '../util/moving-direction.enum';
 import {By} from '@angular/platform-browser';
@@ -72,42 +72,46 @@ describe('EnableBackLinksDirective', () => {
     expect(wizardTestFixture.debugElement.queryAll(By.css('wizard-completion-step')).length).toBe(1);
   });
 
-  it('should be able to leave the completion step', () => {
+  it('should be able to leave the completion step', fakeAsync(() => {
     navigationMode.goToStep(2);
+    tick();
     wizardTestFixture.detectChanges();
 
-    expect(navigationMode.canGoToStep(0)).toBe(true);
-    expect(navigationMode.canGoToStep(1)).toBe(true);
-  });
+    navigationMode.canGoToStep(0).then(result => expect(result).toBe(true));
+    navigationMode.canGoToStep(1).then(result => expect(result).toBe(true));
+  }));
 
 
-  it('should be able to leave the completion step in any direction', () => {
+  it('should be able to leave the completion step in any direction', fakeAsync(() => {
     wizardTest.isValid = false;
 
     navigationMode.goToStep(2);
+    tick();
     wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(2);
     expect(wizardState.currentStep.canExit).toBe(true);
-  });
+  }));
 
-  it('should leave the completion step', () => {
+  it('should leave the completion step', fakeAsync(() => {
     wizardTest.isValid = false;
 
     navigationMode.goToStep(2);
+    tick();
     wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(2);
 
     navigationMode.goToPreviousStep();
+    tick();
     wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(1);
     expect(wizardTest.eventLog)
       .toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 3', 'exit Backwards 3', 'enter Backwards 2']);
-  });
+  }));
 
-  it('should work with changed stepExit value', () => {
+  it('should work with changed stepExit value', fakeAsync(() => {
     wizardTest.isValid = false;
     wizardTest.completionStepExit = (direction: MovingDirection, source: number) => {
       wizardTest.eventLog.push(`changed exit ${MovingDirection[direction]} ${source}`);
@@ -116,17 +120,19 @@ describe('EnableBackLinksDirective', () => {
     expect(wizardState.completed).toBe(false);
 
     navigationMode.goToStep(2);
+    tick();
     wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(2);
     expect(wizardState.completed).toBe(true);
 
     navigationMode.goToPreviousStep();
+    tick();
     wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(1);
     expect(wizardTest.eventLog)
       .toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 3', 'changed exit Backwards 3', 'enter Backwards 2']);
     expect(wizardState.completed).toBe(false);
-  });
+  }));
 });

--- a/src/directives/go-to-step.directive.spec.ts
+++ b/src/directives/go-to-step.directive.spec.ts
@@ -3,7 +3,7 @@
  */
 import {GoToStepDirective} from './go-to-step.directive';
 import {Component} from '@angular/core';
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {WizardModule} from '../wizard.module';
 import {WizardState} from '../navigation/wizard-state.model';
@@ -79,7 +79,7 @@ describe('GoToStepDirective', () => {
     expect(wizardTestFixture.debugElement.queryAll(By.directive(GoToStepDirective)).length).toBe(9);
   });
 
-  it('should move to step correctly', () => {
+  it('should move to step correctly', fakeAsync(() => {
     const firstStepGoToButton = wizardTestFixture.debugElement.query(
       By.css('wizard-step[stepTitle="Steptitle 1"] > button:nth-child(2)')).nativeElement;
     const secondStepGoToButton = wizardTestFixture.debugElement.query(
@@ -94,6 +94,7 @@ describe('GoToStepDirective', () => {
 
     // click button
     firstStepGoToButton.click();
+    tick();
     wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(1);
@@ -103,15 +104,16 @@ describe('GoToStepDirective', () => {
 
     // click button
     secondStepGoToButton.click();
+    tick();
     wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(2);
     expect(wizardSteps[0].selected).toBe(false);
     expect(wizardSteps[1].selected).toBe(false);
     expect(wizardSteps[2].selected).toBe(true);
-  });
+  }));
 
-  it('should jump over an optional step correctly', () => {
+  it('should jump over an optional step correctly', fakeAsync(() => {
     const firstStepGoToButton = wizardTestFixture.debugElement.query(
       By.css('wizard-step[stepTitle="Steptitle 1"] > button:nth-child(3)')).nativeElement;
     const thirdStepGoToButton = wizardTestFixture.debugElement.query(
@@ -126,6 +128,7 @@ describe('GoToStepDirective', () => {
 
     // click button
     firstStepGoToButton.click();
+    tick();
     wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(2);
@@ -135,15 +138,16 @@ describe('GoToStepDirective', () => {
 
     // click button
     thirdStepGoToButton.click();
+    tick();
     wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(0);
     expect(wizardSteps[0].selected).toBe(true);
     expect(wizardSteps[1].selected).toBe(false);
     expect(wizardSteps[2].selected).toBe(false);
-  });
+  }));
 
-  it('should stay at current step correctly', () => {
+  it('should stay at current step correctly', fakeAsync(() => {
     const firstStepGoToButton = wizardTestFixture.debugElement.query(
       By.css('wizard-step[stepTitle="Steptitle 1"] > button:nth-child(1)')).nativeElement;
 
@@ -156,15 +160,16 @@ describe('GoToStepDirective', () => {
 
     // click button
     firstStepGoToButton.click();
+    tick();
     wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(0);
     expect(wizardSteps[0].selected).toBe(true);
     expect(wizardSteps[1].selected).toBe(false);
     expect(wizardSteps[2].selected).toBe(false);
-  });
+  }));
 
-  it('should finalize step correctly', () => {
+  it('should finalize step correctly', fakeAsync(() => {
     const firstStepGoToButton = wizardTestFixture.debugElement.query(
       By.css('wizard-step[stepTitle="Steptitle 1"] > button:nth-child(3)')).nativeElement;
     const thirdStepGoToButton = wizardTestFixture.debugElement.query(
@@ -175,6 +180,7 @@ describe('GoToStepDirective', () => {
 
     // click button
     firstStepGoToButton.click();
+    tick();
     wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(2);
@@ -182,22 +188,23 @@ describe('GoToStepDirective', () => {
 
     // click button
     thirdStepGoToButton.click();
+    tick();
     wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(0);
     expect(wizardTest.eventLog).toEqual(['finalize 1', 'finalize 3']);
-  });
+  }));
 
-  it('should throw an error when using an invalid goToStep value', () => {
+  it('should throw an error when using an invalid goToStep value', fakeAsync(() => {
     const invalidGoToAttribute = wizardTestFixture.debugElement
       .query(By.css('wizard-step[stepTitle="Steptitle 2"]'))
       .queryAll(By.directive(GoToStepDirective))[1].injector.get(GoToStepDirective) as GoToStepDirective;
 
     expect(() => invalidGoToAttribute.destinationStep)
       .toThrow(new Error(`Input 'goToStep' is neither a WizardStep, StepOffset, number or string`));
-  });
+  }));
 
-  it('should return correct destination step for correct goToStep values', () => {
+  it('should return correct destination step for correct goToStep values', fakeAsync(() => {
     const firstGoToAttribute = wizardTestFixture.debugElement
       .query(By.css('wizard-navigation-bar'))
       .queryAll(By.directive(GoToStepDirective))[0].injector.get(GoToStepDirective) as GoToStepDirective;
@@ -218,9 +225,9 @@ describe('GoToStepDirective', () => {
     expect(secondGoToAttribute.destinationStep).toBe(1);
     expect(thirdGoToAttribute.destinationStep).toBe(2);
     expect(fourthGoToAttribute.destinationStep).toBe(0);
-  });
+  }));
 
-  it('should not leave current step if it the destination step can not be entered', () => {
+  it('should not leave current step if it the destination step can not be entered', fakeAsync(() => {
     expect(wizardState.currentStepIndex).toBe(0);
 
     wizardTest.canExit = false;
@@ -231,8 +238,9 @@ describe('GoToStepDirective', () => {
       .queryAll(By.directive(GoToStepDirective))[1].nativeElement;
 
     secondGoToAttribute.click();
+    tick();
     wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(0);
-  });
+  }));
 });

--- a/src/directives/next-step.directive.spec.ts
+++ b/src/directives/next-step.directive.spec.ts
@@ -1,6 +1,6 @@
 import {NextStepDirective} from './next-step.directive';
 import {Component} from '@angular/core';
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {WizardModule} from '../wizard.module';
 import {WizardState} from '../navigation/wizard-state.model';
@@ -62,7 +62,7 @@ describe('NextStepDirective', () => {
       By.directive(NextStepDirective)).length).toBe(3);
   });
 
-  it('should move correctly to the next step', () => {
+  it('should move correctly to the next step', fakeAsync(() => {
     const firstStepButton = wizardTestFixture.debugElement.query(
       By.css('wizard-step[stepTitle="Steptitle 1"] > button[nextStep]')).nativeElement;
     const secondStepButton = wizardTestFixture.debugElement.query(
@@ -72,16 +72,20 @@ describe('NextStepDirective', () => {
 
     // go to second step
     firstStepButton.click();
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(1);
 
     // don't go to third step because it doesn't exist
     secondStepButton.click();
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(1);
-  });
+  }));
 
-  it('should call finalize correctly when going the next step', () => {
+  it('should call finalize correctly when going the next step', fakeAsync(() => {
     const firstStepButtons = wizardTestFixture.debugElement.queryAll(
       By.css('wizard-step[stepTitle="Steptitle 1"] > button[nextStep]'));
 
@@ -89,11 +93,13 @@ describe('NextStepDirective', () => {
 
     // go to second step
     firstStepButtons[0].nativeElement.click();
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardTest.eventLog).toEqual(['finalize 1']);
-  });
+  }));
 
-  it('should call postFinalize correctly when going the next step', () => {
+  it('should call postFinalize correctly when going the next step', fakeAsync(() => {
     const firstStepButtons = wizardTestFixture.debugElement.queryAll(
       By.css('wizard-step[stepTitle="Steptitle 1"] > button[nextStep]'));
 
@@ -101,21 +107,27 @@ describe('NextStepDirective', () => {
 
     // go to second step
     firstStepButtons[1].nativeElement.click();
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardTest.eventLog).toEqual(['finalize 1']);
-  });
+  }));
 
-  it('shouldn\'t call finalize when going to an nonexistent step', () => {
+  it('shouldn\'t call finalize when going to an nonexistent step', fakeAsync(() => {
     const secondStepButton = wizardTestFixture.debugElement.query(
       By.css('wizard-step[stepTitle="Steptitle 2"] > button[nextStep]')).nativeElement;
 
     navigationMode.goToStep(1);
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardTest.eventLog).toEqual([]);
 
     // don't go to third step because it doesn't exist
     secondStepButton.click();
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardTest.eventLog).toEqual([]);
-  });
+  }));
 });

--- a/src/directives/previous-step.directive.spec.ts
+++ b/src/directives/previous-step.directive.spec.ts
@@ -1,6 +1,6 @@
 import {PreviousStepDirective} from './previous-step.directive';
 import {Component} from '@angular/core';
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {WizardModule} from '../wizard.module';
 import {WizardState} from '../navigation/wizard-state.model';
@@ -62,7 +62,7 @@ describe('PreviousStepDirective', () => {
       By.directive(PreviousStepDirective)).length).toBe(3);
   });
 
-  it('should move correctly to the previous step', () => {
+  it('should move correctly to the previous step', fakeAsync(() => {
     const firstStepButton = wizardTestFixture.debugElement.query(
       By.css('wizard-step[stepTitle="Steptitle 1"] > button[previousStep]')).nativeElement;
     const secondStepButton = wizardTestFixture.debugElement.query(
@@ -72,50 +72,63 @@ describe('PreviousStepDirective', () => {
 
     // don't go to zero (-1) step, because it doesn't exist
     firstStepButton.click();
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(0);
 
     // move to second step to test the previousStep directive
     navigationMode.goToStep(1);
+    tick();
     wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(1);
 
     // go back to first step
     secondStepButton.click();
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(0);
-  });
+  }));
 
-  it('should call finalize correctly when going the previous step', () => {
+  it('should call finalize correctly when going the previous step', fakeAsync(() => {
     const secondStepButtons = wizardTestFixture.debugElement.queryAll(
       By.css('wizard-step[stepTitle="Steptitle 2"] > button[previousStep]'));
 
     navigationMode.goToStep(1);
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardTest.eventLog).toEqual([]);
 
     // go to second step
     secondStepButtons[0].nativeElement.click();
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardTest.eventLog).toEqual(['finalize 2']);
-  });
+  }));
 
-  it('should call postFinalize correctly when going the previous step', () => {
+  it('should call postFinalize correctly when going the previous step', fakeAsync(() => {
     const secondStepButtons = wizardTestFixture.debugElement.queryAll(
       By.css('wizard-step[stepTitle="Steptitle 2"] > button[previousStep]'));
 
     navigationMode.goToStep(1);
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardTest.eventLog).toEqual([]);
 
     // go to second step
     secondStepButtons[1].nativeElement.click();
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardTest.eventLog).toEqual(['finalize 2']);
-  });
+  }));
 
-  it('shouldn\'t call finalize when going to an nonexistent step', () => {
+  it('shouldn\'t call finalize when going to an nonexistent step', fakeAsync(() => {
     const firstStepButton = wizardTestFixture.debugElement.query(
       By.css('wizard-step[stepTitle="Steptitle 1"] > button[previousStep]')).nativeElement;
 
@@ -123,7 +136,9 @@ describe('PreviousStepDirective', () => {
 
     // don't go to third step because it doesn't exist
     firstStepButton.click();
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardTest.eventLog).toEqual([]);
-  });
+  }));
 });

--- a/src/directives/selected.directive.spec.ts
+++ b/src/directives/selected.directive.spec.ts
@@ -1,6 +1,5 @@
-import {OptionalStepDirective} from './optional-step.directive';
 import {Component} from '@angular/core';
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {WizardModule} from '../wizard.module';
 import {WizardState} from '../navigation/wizard-state.model';
@@ -58,8 +57,10 @@ describe('SelectedStepDirective', () => {
     expect(wizardState.currentStepIndex).toBe(1);
   });
 
-  it('should reset correctly', () => {
+  it('should reset correctly', fakeAsync(() => {
     navigationMode.goToStep(0);
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(0);
 
@@ -67,5 +68,5 @@ describe('SelectedStepDirective', () => {
     wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(1);
-  });
+  }));
 });

--- a/src/navigation/free-navigation-mode.spec.ts
+++ b/src/navigation/free-navigation-mode.spec.ts
@@ -1,4 +1,4 @@
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {Component, ViewChild} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {WizardModule} from '../wizard.module';
@@ -52,15 +52,15 @@ describe('FreeNavigationMode', () => {
       'Navigation mode is not an instance of FreeNavigationMode');
   });
 
-  it('should return correct can go to step', () => {
-    expect(navigationMode.canGoToStep(-1)).toBe(false);
-    expect(navigationMode.canGoToStep(0)).toBe(true);
-    expect(navigationMode.canGoToStep(1)).toBe(true);
-    expect(navigationMode.canGoToStep(2)).toBe(true);
-    expect(navigationMode.canGoToStep(3)).toBe(false);
-  });
+  it('should return correct can go to step', async(() => {
+    navigationMode.canGoToStep(-1).then(result => expect(result).toBe(false));
+    navigationMode.canGoToStep(0).then(result => expect(result).toBe(true));
+    navigationMode.canGoToStep(1).then(result => expect(result).toBe(true));
+    navigationMode.canGoToStep(2).then(result => expect(result).toBe(true));
+    navigationMode.canGoToStep(3).then(result => expect(result).toBe(false));
+  }));
 
-  it('should go to step', () => {
+  it('should go to step', fakeAsync(() => {
     expect(wizardState.currentStepIndex).toBe(0);
     expect(wizardState.getStepAtIndex(0).selected).toBe(true);
     expect(wizardState.getStepAtIndex(0).completed).toBe(false);
@@ -70,6 +70,8 @@ describe('FreeNavigationMode', () => {
     expect(wizardState.getStepAtIndex(2).completed).toBe(false);
 
     navigationMode.goToStep(1);
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(1);
     expect(wizardState.getStepAtIndex(0).selected).toBe(false);
@@ -81,6 +83,8 @@ describe('FreeNavigationMode', () => {
     expect(wizardState.completed).toBe(false);
 
     navigationMode.goToStep(2);
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(2);
     expect(wizardState.getStepAtIndex(0).selected).toBe(false);
@@ -92,6 +96,8 @@ describe('FreeNavigationMode', () => {
     expect(wizardState.completed).toBe(false);
 
     navigationMode.goToStep(0);
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(0);
     expect(wizardState.getStepAtIndex(0).selected).toBe(true);
@@ -103,6 +109,8 @@ describe('FreeNavigationMode', () => {
     expect(wizardState.completed).toBe(true);
 
     navigationMode.goToStep(1);
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(1);
     expect(wizardState.getStepAtIndex(0).selected).toBe(false);
@@ -114,6 +122,8 @@ describe('FreeNavigationMode', () => {
     expect(wizardState.completed).toBe(true);
 
     navigationMode.goToStep(2);
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(2);
     expect(wizardState.getStepAtIndex(0).selected).toBe(false);
@@ -125,6 +135,8 @@ describe('FreeNavigationMode', () => {
     expect(wizardState.completed).toBe(true);
 
     navigationMode.goToStep(1);
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(1);
     expect(wizardState.getStepAtIndex(0).selected).toBe(false);
@@ -134,11 +146,11 @@ describe('FreeNavigationMode', () => {
     expect(wizardState.getStepAtIndex(2).selected).toBe(false);
     expect(wizardState.getStepAtIndex(2).completed).toBe(true);
     expect(wizardState.completed).toBe(true);
-  });
+  }));
 
-  it('should go to next step', () => {
+  it('should go to next step', fakeAsync(() => {
     navigationMode.goToNextStep();
-
+    tick();
     wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(1);
@@ -149,12 +161,14 @@ describe('FreeNavigationMode', () => {
     expect(wizardState.getStepAtIndex(2).selected).toBe(false);
     expect(wizardState.getStepAtIndex(2).completed).toBe(false);
     expect(wizardState.completed).toBe(false);
-  });
+  }));
 
-  it('should go to previous step', () => {
+  it('should go to previous step', fakeAsync(() => {
     expect(wizardState.getStepAtIndex(0).completed).toBe(false);
 
     navigationMode.goToStep(1);
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(1);
     expect(wizardState.getStepAtIndex(0).selected).toBe(false);
@@ -166,6 +180,8 @@ describe('FreeNavigationMode', () => {
     expect(wizardState.completed).toBe(false);
 
     navigationMode.goToPreviousStep();
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(0);
     expect(wizardState.getStepAtIndex(0).selected).toBe(true);
@@ -175,12 +191,14 @@ describe('FreeNavigationMode', () => {
     expect(wizardState.getStepAtIndex(2).selected).toBe(false);
     expect(wizardState.getStepAtIndex(2).completed).toBe(false);
     expect(wizardState.completed).toBe(false);
-  });
+  }));
 
-  it('should stay at the current step', () => {
+  it('should stay at the current step', fakeAsync(() => {
     expect(wizardState.getStepAtIndex(0).completed).toBe(false);
 
     navigationMode.goToPreviousStep();
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(0);
     expect(wizardState.getStepAtIndex(0).selected).toBe(true);
@@ -192,6 +210,8 @@ describe('FreeNavigationMode', () => {
     expect(wizardState.completed).toBe(false);
 
     navigationMode.goToStep(-1);
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(0);
     expect(wizardState.getStepAtIndex(0).selected).toBe(true);
@@ -203,6 +223,8 @@ describe('FreeNavigationMode', () => {
     expect(wizardState.completed).toBe(false);
 
     navigationMode.goToStep(0);
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(0);
     expect(wizardState.getStepAtIndex(0).selected).toBe(true);
@@ -212,11 +234,16 @@ describe('FreeNavigationMode', () => {
     expect(wizardState.getStepAtIndex(2).selected).toBe(false);
     expect(wizardState.getStepAtIndex(2).completed).toBe(false);
     expect(wizardState.completed).toBe(false);
-  });
+  }));
 
-  it('should reset the wizard correctly', () => {
+  it('should reset the wizard correctly', fakeAsync(() => {
     navigationMode.goToNextStep();
+    tick();
+    wizardTestFixture.detectChanges();
+
     navigationMode.goToNextStep();
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(2);
     expect(wizardState.getStepAtIndex(0).selected).toBe(false);
@@ -261,5 +288,5 @@ describe('FreeNavigationMode', () => {
     expect(wizardState.getStepAtIndex(2).selected).toBe(true);
     expect(wizardState.getStepAtIndex(2).completed).toBe(false);
     expect(wizardState.completed).toBe(false);
-  });
+  }));
 });

--- a/src/navigation/navigation-mode.interface.ts
+++ b/src/navigation/navigation-mode.interface.ts
@@ -17,7 +17,7 @@ export abstract class NavigationMode {
    * @param {number} destinationIndex The index of the destination step
    * @returns {boolean} True if the destination step can be transitioned to, false otherwise
    */
-  abstract canGoToStep(destinationIndex: number): boolean;
+  abstract canGoToStep(destinationIndex: number): Promise<boolean>;
 
   /**
    * Tries to transition to the wizard step, as denoted by the given destination index.

--- a/src/navigation/navigation-mode.interface.ts
+++ b/src/navigation/navigation-mode.interface.ts
@@ -15,7 +15,7 @@ export abstract class NavigationMode {
    * Checks, whether a wizard step, as defined by the given destination index, can be transitioned to.
    *
    * @param {number} destinationIndex The index of the destination step
-   * @returns {boolean} True if the destination step can be transitioned to, false otherwise
+   * @returns {Promise<boolean>} A [[Promise]] containing `true`, if the destination step can be transitioned to and false otherwise
    */
   abstract canGoToStep(destinationIndex: number): Promise<boolean>;
 

--- a/src/navigation/semi-strict-navigation-mode.spec.ts
+++ b/src/navigation/semi-strict-navigation-mode.spec.ts
@@ -1,4 +1,4 @@
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {Component, ViewChild} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {WizardModule} from '../wizard.module';
@@ -52,15 +52,15 @@ describe('SemiStrictNavigationMode', () => {
       'Navigation mode is not an instance of SemiStrictNavigationMode');
   });
 
-  it('should return correct can go to step', () => {
-    expect(navigationMode.canGoToStep(-1)).toBe(false);
-    expect(navigationMode.canGoToStep(0)).toBe(true);
-    expect(navigationMode.canGoToStep(1)).toBe(true);
-    expect(navigationMode.canGoToStep(2)).toBe(false);
-    expect(navigationMode.canGoToStep(3)).toBe(false);
-  });
+  it('should return correct can go to step', async(() => {
+    navigationMode.canGoToStep(-1).then(result => expect(result).toBe(false));
+    navigationMode.canGoToStep(0).then(result => expect(result).toBe(true));
+    navigationMode.canGoToStep(1).then(result => expect(result).toBe(true));
+    navigationMode.canGoToStep(2).then(result => expect(result).toBe(false));
+    navigationMode.canGoToStep(3).then(result => expect(result).toBe(false));
+  }));
 
-  it('should go to step', () => {
+  it('should go to step', fakeAsync(() => {
     expect(wizardState.currentStepIndex).toBe(0);
     expect(wizardState.getStepAtIndex(0).selected).toBe(true);
     expect(wizardState.getStepAtIndex(0).completed).toBe(false);
@@ -70,6 +70,8 @@ describe('SemiStrictNavigationMode', () => {
     expect(wizardState.getStepAtIndex(2).completed).toBe(false);
 
     navigationMode.goToStep(1);
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(1);
     expect(wizardState.getStepAtIndex(0).selected).toBe(false);
@@ -81,6 +83,8 @@ describe('SemiStrictNavigationMode', () => {
     expect(wizardState.completed).toBe(false);
 
     navigationMode.goToStep(2);
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(2);
     expect(wizardState.getStepAtIndex(0).selected).toBe(false);
@@ -92,6 +96,8 @@ describe('SemiStrictNavigationMode', () => {
     expect(wizardState.completed).toBe(true);
 
     navigationMode.goToStep(0);
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(0);
     expect(wizardState.getStepAtIndex(0).selected).toBe(true);
@@ -103,6 +109,8 @@ describe('SemiStrictNavigationMode', () => {
     expect(wizardState.completed).toBe(false);
 
     navigationMode.goToStep(1);
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(1);
     expect(wizardState.getStepAtIndex(0).selected).toBe(false);
@@ -114,6 +122,8 @@ describe('SemiStrictNavigationMode', () => {
     expect(wizardState.completed).toBe(false);
 
     navigationMode.goToStep(2);
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(2);
     expect(wizardState.getStepAtIndex(0).selected).toBe(false);
@@ -125,6 +135,8 @@ describe('SemiStrictNavigationMode', () => {
     expect(wizardState.completed).toBe(true);
 
     navigationMode.goToStep(1);
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(1);
     expect(wizardState.getStepAtIndex(0).selected).toBe(false);
@@ -134,11 +146,11 @@ describe('SemiStrictNavigationMode', () => {
     expect(wizardState.getStepAtIndex(2).selected).toBe(false);
     expect(wizardState.getStepAtIndex(2).completed).toBe(false);
     expect(wizardState.completed).toBe(false);
-  });
+  }));
 
-  it('should go to next step', () => {
+  it('should go to next step', fakeAsync(() => {
     navigationMode.goToNextStep();
-
+    tick();
     wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(1);
@@ -149,12 +161,14 @@ describe('SemiStrictNavigationMode', () => {
     expect(wizardState.getStepAtIndex(2).selected).toBe(false);
     expect(wizardState.getStepAtIndex(2).completed).toBe(false);
     expect(wizardState.completed).toBe(false);
-  });
+  }));
 
-  it('should go to previous step', () => {
+  it('should go to previous step', fakeAsync(() => {
     expect(wizardState.getStepAtIndex(0).completed).toBe(false);
 
     navigationMode.goToStep(1);
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(1);
     expect(wizardState.getStepAtIndex(0).selected).toBe(false);
@@ -166,6 +180,8 @@ describe('SemiStrictNavigationMode', () => {
     expect(wizardState.completed).toBe(false);
 
     navigationMode.goToPreviousStep();
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(0);
     expect(wizardState.getStepAtIndex(0).selected).toBe(true);
@@ -175,12 +191,14 @@ describe('SemiStrictNavigationMode', () => {
     expect(wizardState.getStepAtIndex(2).selected).toBe(false);
     expect(wizardState.getStepAtIndex(2).completed).toBe(false);
     expect(wizardState.completed).toBe(false);
-  });
+  }));
 
-  it('should stay at the current step', () => {
+  it('should stay at the current step', fakeAsync(() => {
     expect(wizardState.getStepAtIndex(0).completed).toBe(false);
 
     navigationMode.goToPreviousStep();
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(0);
     expect(wizardState.getStepAtIndex(0).selected).toBe(true);
@@ -192,6 +210,8 @@ describe('SemiStrictNavigationMode', () => {
     expect(wizardState.completed).toBe(false);
 
     navigationMode.goToStep(-1);
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(0);
     expect(wizardState.getStepAtIndex(0).selected).toBe(true);
@@ -203,6 +223,8 @@ describe('SemiStrictNavigationMode', () => {
     expect(wizardState.completed).toBe(false);
 
     navigationMode.goToStep(0);
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(0);
     expect(wizardState.getStepAtIndex(0).selected).toBe(true);
@@ -212,11 +234,16 @@ describe('SemiStrictNavigationMode', () => {
     expect(wizardState.getStepAtIndex(2).selected).toBe(false);
     expect(wizardState.getStepAtIndex(2).completed).toBe(false);
     expect(wizardState.completed).toBe(false);
-  });
+  }));
 
-  it('should reset the wizard correctly', () => {
+  it('should reset the wizard correctly', fakeAsync(() => {
     navigationMode.goToNextStep();
+    tick();
+    wizardTestFixture.detectChanges();
+
     navigationMode.goToNextStep();
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(2);
     expect(wizardState.getStepAtIndex(0).selected).toBe(false);
@@ -273,5 +300,5 @@ describe('SemiStrictNavigationMode', () => {
     expect(wizardState.getStepAtIndex(2).selected).toBe(false);
     expect(wizardState.getStepAtIndex(2).completed).toBe(false);
     expect(wizardState.completed).toBe(false);
-  });
+  }));
 });

--- a/src/navigation/semi-strict-navigation-mode.ts
+++ b/src/navigation/semi-strict-navigation-mode.ts
@@ -32,23 +32,37 @@ export class SemiStrictNavigationMode extends NavigationMode {
    * @param {number} destinationIndex The index of the destination wizard step
    * @returns {boolean} True if the destination wizard step can be entered, false otherwise
    */
-  canGoToStep(destinationIndex: number): boolean {
+  canGoToStep(destinationIndex: number): Promise<boolean> {
     const hasStep = this.wizardState.hasStep(destinationIndex);
 
     const movingDirection = this.wizardState.getMovingDirection(destinationIndex);
 
-    const canExitCurrentStep = () => this.wizardState.currentStep.canExitStep(movingDirection);
-    const canEnterDestinationStep = () => this.wizardState.getStepAtIndex(destinationIndex).canEnterStep(movingDirection);
+    const canExitCurrentStep = (previous: boolean) => {
+      return previous ? this.wizardState.currentStep.canExitStep(movingDirection) : Promise.resolve(false);
+    };
 
-    const allNormalStepsCompleted = this.wizardState.wizardSteps
-      .filter((step, index) => index < destinationIndex)
-      .every(step => step.completed || step.optional || step.selected);
+    const canEnterDestinationStep = (previous: boolean) => {
+      return previous ? this.wizardState.getStepAtIndex(destinationIndex).canEnterStep(movingDirection) : Promise.resolve(false);
+    };
 
     // provide the destination step as a lambda in case the index doesn't exist (i.e. hasStep === false)
-    const destinationStep = () => this.wizardState.getStepAtIndex(destinationIndex);
+    const destinationStep = (previous: boolean) => {
+      if (previous) {
+        const allNormalStepsCompleted = this.wizardState.wizardSteps
+          .filter((step, index) => index < destinationIndex)
+          .every(step => step.completed || step.optional || step.selected);
 
-    return hasStep && canExitCurrentStep() && canEnterDestinationStep() &&
-      (!(destinationStep() instanceof WizardCompletionStep) || allNormalStepsCompleted);
+        return Promise.resolve(
+          !(this.wizardState.getStepAtIndex(destinationIndex) instanceof WizardCompletionStep) || allNormalStepsCompleted);
+      } else {
+        return Promise.resolve(false);
+      }
+    };
+
+    return Promise.resolve(hasStep)
+        .then(canExitCurrentStep)
+        .then(canEnterDestinationStep)
+        .then(destinationStep);
   }
 
   /**
@@ -68,35 +82,37 @@ export class SemiStrictNavigationMode extends NavigationMode {
    * @param {EventEmitter<void>} postFinalize An event emitter, to be called after the step has been transitioned
    */
   goToStep(destinationIndex: number, preFinalize?: EventEmitter<void>, postFinalize?: EventEmitter<void>): void {
-    const movingDirection: MovingDirection = this.wizardState.getMovingDirection(destinationIndex);
+    this.canGoToStep(destinationIndex).then(navigationAllowed => {
+      if (navigationAllowed) {
+        // the current step can be exited in the given direction
+        const movingDirection: MovingDirection = this.wizardState.getMovingDirection(destinationIndex);
 
-    // the current step can be exited in the given direction
-    if (this.canGoToStep(destinationIndex)) {
-      /* istanbul ignore if */
-      if (preFinalize) {
-        preFinalize.emit();
+        /* istanbul ignore if */
+        if (preFinalize) {
+          preFinalize.emit();
+        }
+
+        // leave current step
+        this.wizardState.currentStep.completed = true;
+        this.wizardState.currentStep.exit(movingDirection);
+        this.wizardState.currentStep.selected = false;
+
+        this.wizardState.currentStepIndex = destinationIndex;
+
+        // go to next step
+        this.wizardState.currentStep.enter(movingDirection);
+        this.wizardState.currentStep.selected = true;
+
+        /* istanbul ignore if */
+        if (postFinalize) {
+          postFinalize.emit();
+        }
+      } else {
+        // if the current step can't be left, reenter the current step
+        this.wizardState.currentStep.exit(MovingDirection.Stay);
+        this.wizardState.currentStep.enter(MovingDirection.Stay);
       }
-
-      // leave current step
-      this.wizardState.currentStep.completed = true;
-      this.wizardState.currentStep.exit(movingDirection);
-      this.wizardState.currentStep.selected = false;
-
-      this.wizardState.currentStepIndex = destinationIndex;
-
-      // go to next step
-      this.wizardState.currentStep.enter(movingDirection);
-      this.wizardState.currentStep.selected = true;
-
-      /* istanbul ignore if */
-      if (postFinalize) {
-        postFinalize.emit();
-      }
-    } else {
-      // if the current step can't be left, reenter the current step
-      this.wizardState.currentStep.exit(MovingDirection.Stay);
-      this.wizardState.currentStep.enter(MovingDirection.Stay);
-    }
+    });
   }
 
   /**

--- a/src/navigation/strict-navigation-mode.spec.ts
+++ b/src/navigation/strict-navigation-mode.spec.ts
@@ -1,4 +1,4 @@
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {Component, ViewChild} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {WizardStep} from '../util/wizard-step.interface';
@@ -73,18 +73,20 @@ describe('StrictNavigationMode', () => {
       'Navigation mode is not an instance of StrictNavigationMode');
   });
 
-  it('should return correct can go to step', () => {
-    expect(navigationMode.canGoToStep(-1)).toBe(false);
-    expect(navigationMode.canGoToStep(0)).toBe(true);
-    expect(navigationMode.canGoToStep(1)).toBe(true);
-    expect(navigationMode.canGoToStep(2)).toBe(false);
-    expect(navigationMode.canGoToStep(3)).toBe(false);
-  });
+  it('should return correct can go to step', async(() => {
+    navigationMode.canGoToStep(-1).then(result => expect(result).toBe(false));
+    navigationMode.canGoToStep(0).then(result => expect(result).toBe(true));
+    navigationMode.canGoToStep(1).then(result => expect(result).toBe(true));
+    navigationMode.canGoToStep(2).then(result => expect(result).toBe(false));
+    navigationMode.canGoToStep(3).then(result => expect(result).toBe(false));
+  }));
 
-  it('should go to step', () => {
+  it('should go to step', fakeAsync(() => {
     checkWizardSteps(wizardState.wizardSteps, 0);
 
     navigationMode.goToStep(1);
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(1);
     expect(wizardState.currentStep).toBe(wizardState.getStepAtIndex(1));
@@ -93,6 +95,8 @@ describe('StrictNavigationMode', () => {
     checkWizardSteps(wizardState.wizardSteps, 1);
 
     navigationMode.goToStep(2);
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(2);
     expect(wizardState.currentStep).toBe(wizardState.getStepAtIndex(2));
@@ -101,6 +105,8 @@ describe('StrictNavigationMode', () => {
     checkWizardSteps(wizardState.wizardSteps, 2);
 
     navigationMode.goToStep(0);
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(0);
     expect(wizardState.currentStep).toBe(wizardState.getStepAtIndex(0));
@@ -109,6 +115,8 @@ describe('StrictNavigationMode', () => {
     checkWizardSteps(wizardState.wizardSteps, 0);
 
     navigationMode.goToStep(1);
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(1);
     expect(wizardState.currentStep).toBe(wizardState.getStepAtIndex(1));
@@ -117,6 +125,8 @@ describe('StrictNavigationMode', () => {
     checkWizardSteps(wizardState.wizardSteps, 1);
 
     navigationMode.goToStep(2);
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(2);
     expect(wizardState.currentStep).toBe(wizardState.getStepAtIndex(2));
@@ -125,17 +135,19 @@ describe('StrictNavigationMode', () => {
     checkWizardSteps(wizardState.wizardSteps, 2);
 
     navigationMode.goToStep(1);
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(1);
     expect(wizardState.currentStep).toBe(wizardState.getStepAtIndex(1));
     expect(wizardState.currentStep.completed).toBe(true);
 
     checkWizardSteps(wizardState.wizardSteps, 1);
-  });
+  }));
 
-  it('should go to next step', () => {
+  it('should go to next step', fakeAsync(() => {
     navigationMode.goToNextStep();
-
+    tick();
     wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(1);
@@ -143,28 +155,37 @@ describe('StrictNavigationMode', () => {
     expect(wizardState.currentStep.completed).toBe(false);
 
     checkWizardSteps(wizardState.wizardSteps, 1);
-  });
+  }));
 
-  it('should go to previous step', () => {
+  it('should go to previous step', fakeAsync(() => {
     expect(wizardState.getStepAtIndex(0).completed).toBe(false);
     checkWizardSteps(wizardState.wizardSteps, 0);
 
     navigationMode.goToStep(1);
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.getStepAtIndex(0).completed).toBe(true);
     checkWizardSteps(wizardState.wizardSteps, 1);
 
     navigationMode.goToPreviousStep();
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(0);
     expect(wizardState.currentStep).toBe(wizardState.getStepAtIndex(0));
 
     checkWizardSteps(wizardState.wizardSteps, 0);
-  });
+  }));
 
-  it('should reset the wizard correctly', () => {
+  it('should reset the wizard correctly', fakeAsync(() => {
     navigationMode.goToNextStep();
+    tick();
+    wizardTestFixture.detectChanges();
+
     navigationMode.goToNextStep();
+    tick();
+    wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(2);
     expect(wizardState.getStepAtIndex(0).selected).toBe(false);
@@ -221,5 +242,5 @@ describe('StrictNavigationMode', () => {
     expect(wizardState.getStepAtIndex(2).selected).toBe(false);
     expect(wizardState.getStepAtIndex(2).completed).toBe(false);
     expect(wizardState.completed).toBe(false);
-  });
+  }));
 });

--- a/src/util/wizard-completion-step.interface.spec.ts
+++ b/src/util/wizard-completion-step.interface.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Created by marc on 20.05.17.
  */
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {Component} from '@angular/core';
 import {MovingDirection} from './moving-direction.enum';
 import {By} from '@angular/platform-browser';
@@ -62,45 +62,50 @@ describe('WizardCompletionStep', () => {
     expect(wizardTestFixture.debugElement.queryAll(By.css('wizard-completion-step')).length).toBe(1);
   });
 
-  it('should set the wizard as completed after entering the completion step', () => {
+  it('should set the wizard as completed after entering the completion step', fakeAsync(() => {
     navigationMode.goToStep(2);
+    tick();
     wizardTestFixture.detectChanges();
 
     expect(wizardState.completed).toBe(true);
-  });
+  }));
 
-  it('should be unable to leave the completion step', () => {
+  it('should be unable to leave the completion step', fakeAsync(() => {
     navigationMode.goToStep(2);
+    tick();
     wizardTestFixture.detectChanges();
 
-    expect(navigationMode.canGoToStep(0)).toBe(false);
-    expect(navigationMode.canGoToStep(1)).toBe(false);
-  });
+    navigationMode.canGoToStep(0).then(result => expect(result).toBe(false));
+    navigationMode.canGoToStep(1).then(result => expect(result).toBe(false));
+  }));
 
 
-  it('should not be able to leave the completion step in any direction', () => {
+  it('should not be able to leave the completion step in any direction', fakeAsync(() => {
     wizardTest.isValid = false;
 
     navigationMode.goToStep(2);
+    tick();
     wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(2);
     expect(wizardState.currentStep.canExit).toBe(false);
-  });
+  }));
 
-  it('should not leave the completion step if it can\'t be exited', () => {
+  it('should not leave the completion step if it can\'t be exited', fakeAsync(() => {
     wizardTest.isValid = false;
 
     navigationMode.goToStep(2);
+    tick();
     wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(2);
 
     navigationMode.goToPreviousStep();
+    tick();
     wizardTestFixture.detectChanges();
 
     expect(wizardState.currentStepIndex).toBe(2);
     expect(wizardTest.eventLog)
       .toEqual(['enter Forwards 1', 'exit Forwards 1', 'enter Forwards 3', 'enter Stay 3']);
-  });
+  }));
 });

--- a/src/util/wizard-step.interface.spec.ts
+++ b/src/util/wizard-step.interface.spec.ts
@@ -86,7 +86,7 @@ describe('WizardStep', () => {
     expect({title: 'Test stepTitle'} instanceof WizardStep).toBe(false);
   });
 
-  it('should evaluate canEnter  correctly', fakeAsync(() => {
+  it('should evaluate canEnter with boolean values correctly', fakeAsync(() => {
     wizardTest.secondStep.canEnterStep(MovingDirection.Backwards).then(result => expect(result).toBe(true));
     wizardTest.secondStep.canEnterStep(MovingDirection.Forwards).then(result => expect(result).toBe(true));
 
@@ -103,7 +103,9 @@ describe('WizardStep', () => {
 
     wizardTest.secondStep.canEnterStep(MovingDirection.Backwards).then(result => expect(result).toBe(false));
     wizardTest.secondStep.canEnterStep(MovingDirection.Forwards).then(result => expect(result).toBe(false));
+  }));
 
+  it('should evaluate canEnter with functions returning a boolean value correctly', fakeAsync(() => {
     wizardTest.canEnter = (direction) => direction === MovingDirection.Forwards;
     tick();
     wizardTestFixture.detectChanges();
@@ -117,7 +119,9 @@ describe('WizardStep', () => {
 
     wizardTest.secondStep.canEnterStep(MovingDirection.Backwards).then(result => expect(result).toBe(true));
     wizardTest.secondStep.canEnterStep(MovingDirection.Forwards).then(result => expect(result).toBe(false));
+  }));
 
+  it('should evaluate canEnter with functions returning a promise correctly', fakeAsync(() => {
     wizardTest.canEnter = (direction) => Promise.resolve(direction === MovingDirection.Forwards);
     tick();
     wizardTestFixture.detectChanges();
@@ -131,7 +135,9 @@ describe('WizardStep', () => {
 
     wizardTest.secondStep.canEnterStep(MovingDirection.Backwards).then(result => expect(result).toBe(true));
     wizardTest.secondStep.canEnterStep(MovingDirection.Forwards).then(result => expect(result).toBe(false));
+  }));
 
+  it('should evaluate canEnter throwing an error correctly', fakeAsync(() => {
     wizardTest.canEnter = 'malformed input';
     tick();
     wizardTestFixture.detectChanges();
@@ -155,7 +161,7 @@ describe('WizardStep', () => {
       .catch(error => expect(error).toEqual(new Error(`malformed input`)));
   }));
 
-  it('should evaluate canExit correctly', fakeAsync(() => {
+  it('should evaluate canExit with boolean values correctly', fakeAsync(() => {
     wizardTest.secondStep.canExitStep(MovingDirection.Backwards).then(result => expect(result).toBe(true));
     wizardTest.secondStep.canExitStep(MovingDirection.Forwards).then(result => expect(result).toBe(true));
 
@@ -172,7 +178,9 @@ describe('WizardStep', () => {
 
     wizardTest.secondStep.canExitStep(MovingDirection.Backwards).then(result => expect(result).toBe(false));
     wizardTest.secondStep.canExitStep(MovingDirection.Forwards).then(result => expect(result).toBe(false));
+  }));
 
+  it('should evaluate canExit with functions returning a boolean value correctly', fakeAsync(() => {
     wizardTest.canExit = (direction) => direction === MovingDirection.Forwards;
     tick();
     wizardTestFixture.detectChanges();
@@ -186,7 +194,9 @@ describe('WizardStep', () => {
 
     wizardTest.secondStep.canExitStep(MovingDirection.Backwards).then(result => expect(result).toBe(true));
     wizardTest.secondStep.canExitStep(MovingDirection.Forwards).then(result => expect(result).toBe(false));
+  }));
 
+  it('should evaluate canExit with functions returning a promise correctly', fakeAsync(() => {
     wizardTest.canExit = (direction) => Promise.resolve(direction === MovingDirection.Forwards);
     tick();
     wizardTestFixture.detectChanges();
@@ -200,7 +210,9 @@ describe('WizardStep', () => {
 
     wizardTest.secondStep.canExitStep(MovingDirection.Backwards).then(result => expect(result).toBe(true));
     wizardTest.secondStep.canExitStep(MovingDirection.Forwards).then(result => expect(result).toBe(false));
+  }));
 
+  it('should evaluate canExit throwing an error correctly', fakeAsync(() => {
     wizardTest.canExit = 'malformed input';
     tick();
     wizardTestFixture.detectChanges();

--- a/src/util/wizard-step.interface.ts
+++ b/src/util/wizard-step.interface.ts
@@ -59,26 +59,26 @@ export abstract class WizardStep {
   public optional = false;
 
   /**
-   * A function taking a [[MovingDirection]], or boolean returning true, if the step can be entered and false otherwise.
+   * A function or boolean deciding, if this step can be entered
    */
   @Input()
   public canEnter: ((direction: MovingDirection) => boolean) | ((direction: MovingDirection) => Promise<boolean>) | boolean = true;
 
   /**
-   * A function taking a [[MovingDirection]], or boolean returning true, if the step can be exited and false otherwise.
+   * A function or boolean deciding, if this step can be exited
    */
   @Input()
   public canExit: ((direction: MovingDirection) => boolean) | ((direction: MovingDirection) => Promise<boolean>) | boolean = true;
 
   /**
-   * This EventEmitter is called when the step is entered.
+   * This [[EventEmitter]] is called when the step is entered.
    * The bound method should be used to do initialization work.
    */
   @Output()
   public stepEnter: EventEmitter<MovingDirection> = new EventEmitter<MovingDirection>();
 
   /**
-   * This EventEmitter is called when the step is exited.
+   * This [[EventEmitter]] is called when the step is exited.
    * The bound method can be used to do cleanup work.
    */
   @Output()
@@ -101,7 +101,7 @@ export abstract class WizardStep {
    *
    * @param condition A condition variable, deciding if the step can be transitioned
    * @param direction The direction in which this step should be transitioned
-   * @returns {boolean} True if this step can transitioned in the given direction
+   * @returns {Promise<boolean>} A [[Promise]] containing `true`, if this step can transitioned in the given direction
    * @throws An `Error` is thrown if `condition` is neither a function nor a boolean
    */
   private static canTransitionStep(condition:
@@ -142,7 +142,7 @@ export abstract class WizardStep {
    * nor a function.
    *
    * @param direction The direction in which this step should be entered
-   * @returns {boolean} True if the step can be entered in the given direction, false otherwise
+   * @returns {Promise<boolean>} A [[Promise]] containing `true`, if the step can be entered in the given direction, false otherwise
    * @throws An `Error` is thrown if `anEnter` is neither a function nor a boolean
    */
   public canEnterStep(direction: MovingDirection): Promise<boolean> {
@@ -155,7 +155,7 @@ export abstract class WizardStep {
    * nor a function.
    *
    * @param direction The direction in which this step should be left
-   * @returns {boolean} True if the step can be exited in the given direction, false otherwise
+   * @returns {Promise<boolean>} A [[Promise]] containing `true`, if the step can be exited in the given direction, false otherwise
    * @throws An `Error` is thrown if `canExit` is neither a function nor a boolean
    */
   public canExitStep(direction: MovingDirection): Promise<boolean> {


### PR DESCRIPTION
This PR closes #38.
To achieve this, it was necessary to make change the internal step navigation to work via `Promise` objects.