### PR TITLE
Remove bad directive selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,15 +269,13 @@ Be aware, that you can only use `[wizardStepTitle]` together with Angular, becau
 
 ### \[optionalStep\]
 If you need to define an optional step, that doesn't need to be done to continue to the next steps, you can define an optional step 
-by adding the `optionalStep` directive to the step you want to declare as optional. 
-To add the `optionalStep` directive to a wizard step, you can either add `optional` or `optionalStep` to the step definition.
+by adding the `optionalStep` directive to the step you want to declare as optional.
 
 ### \[selectedStep\]
 In some cases it may be a better choice to set the default wizard step not via a static number.
 Another way to set the default wizard step is by using the `selectedStep` directive.
 When attaching the `selectedStep` directive to an arbitrary wizard step, it will be marked as the default wizard step,
 which is shown directly after the wizard startup.
-To add the `selectedStep` directive to a wizard step, you can either add `selected` or `selectedStep` to the step definition. 
 
 ### \[goToStep\]
 `ng2-archwizard` has three directives, that allow moving between steps.

--- a/src/directives/optional-step.directive.spec.ts
+++ b/src/directives/optional-step.directive.spec.ts
@@ -13,7 +13,7 @@ import {NavigationMode} from '../navigation/navigation-mode.interface';
       <wizard-step stepTitle='Steptitle 1'>
         Step 1
       </wizard-step>
-      <wizard-step stepTitle='Steptitle 2' optional>
+      <wizard-step stepTitle='Steptitle 2' optionalStep>
         Step 2
       </wizard-step>
       <wizard-step stepTitle='Steptitle 3'>

--- a/src/directives/optional-step.directive.ts
+++ b/src/directives/optional-step.directive.ts
@@ -24,7 +24,7 @@ import {WizardStep} from '../util/wizard-step.interface';
  * @author Marc Arndt
  */
 @Directive({
-  selector: '[optional], [optionalStep]'
+  selector: '[optionalStep]'
 })
 export class OptionalStepDirective implements OnInit {
   /**

--- a/src/directives/reset-wizard.directive.spec.ts
+++ b/src/directives/reset-wizard.directive.spec.ts
@@ -18,7 +18,6 @@ import {ResetWizardDirective} from './reset-wizard.directive';
         Step 2
         <button type="button" resetWizard>Reset (normal)</button>
         <button type="button" resetWizard (finalize)='cleanup()'>Reset (cleanup)</button>
-        <button type="button" reset (finalize)='cleanup()'>Reset (cleanup short)</button>
       </wizard-step>
     </wizard>
   `
@@ -56,10 +55,10 @@ describe('ResetWizardDirective', () => {
 
   it('should create an instance', () => {
     expect(wizardTestFixture.debugElement.query(By.directive(ResetWizardDirective))).toBeTruthy();
-    expect(wizardTestFixture.debugElement.queryAll(By.directive(ResetWizardDirective)).length).toBe(3);
+    expect(wizardTestFixture.debugElement.queryAll(By.directive(ResetWizardDirective)).length).toBe(2);
   });
 
-  it('should reset the wizard correctly 1', fakeAsync(() => {
+  it('should reset the wizard correctly without finalize input', fakeAsync(() => {
     let resetButtons = wizardTestFixture.debugElement
       .queryAll(By.directive(ResetWizardDirective));
 
@@ -84,7 +83,7 @@ describe('ResetWizardDirective', () => {
     expect(wizardTest.eventLog).toEqual([]);
   }));
 
-  it('should reset the wizard correctly 2', fakeAsync(() => {
+  it('should reset the wizard correctly with finalize input', fakeAsync(() => {
     let resetButtons = wizardTestFixture.debugElement
       .queryAll(By.directive(ResetWizardDirective));
 
@@ -99,31 +98,6 @@ describe('ResetWizardDirective', () => {
     expect(wizardTest.eventLog).toEqual([]);
 
     resetButtons[1].nativeElement.click();
-    tick();
-    wizardTestFixture.detectChanges();
-
-    expect(wizardState.getStepAtIndex(0).selected).toBe(true);
-    expect(wizardState.getStepAtIndex(0).completed).toBe(false);
-    expect(wizardState.getStepAtIndex(1).selected).toBe(false);
-    expect(wizardState.getStepAtIndex(1).completed).toBe(false);
-    expect(wizardTest.eventLog).toEqual(['Cleanup done!']);
-  }));
-
-  it('should reset the wizard correctly 3', fakeAsync(() => {
-    let resetButtons = wizardTestFixture.debugElement
-      .queryAll(By.directive(ResetWizardDirective));
-
-    navigationMode.goToStep(1);
-    tick();
-    wizardTestFixture.detectChanges();
-
-    expect(wizardState.getStepAtIndex(0).selected).toBe(false);
-    expect(wizardState.getStepAtIndex(0).completed).toBe(true);
-    expect(wizardState.getStepAtIndex(1).selected).toBe(true);
-    expect(wizardState.getStepAtIndex(1).completed).toBe(false);
-    expect(wizardTest.eventLog).toEqual([]);
-
-    resetButtons[2].nativeElement.click();
     tick();
     wizardTestFixture.detectChanges();
 

--- a/src/directives/reset-wizard.directive.ts
+++ b/src/directives/reset-wizard.directive.ts
@@ -15,7 +15,7 @@ import {NavigationMode} from '../navigation/navigation-mode.interface';
  * @author Marc Arndt
  */
 @Directive({
-  selector: '[reset], [resetWizard]'
+  selector: '[resetWizard]'
 })
 export class ResetWizardDirective {
   /**

--- a/src/directives/selected-step.directive.spec.ts
+++ b/src/directives/selected-step.directive.spec.ts
@@ -4,6 +4,7 @@ import {By} from '@angular/platform-browser';
 import {ArchwizardModule} from '../archwizard.module';
 import {WizardState} from '../navigation/wizard-state.model';
 import {NavigationMode} from '../navigation/navigation-mode.interface';
+import {SelectedStepDirective} from './selected-step.directive';
 
 @Component({
   selector: 'test-wizard',
@@ -12,7 +13,7 @@ import {NavigationMode} from '../navigation/navigation-mode.interface';
       <wizard-step stepTitle='Steptitle 1'>
         Step 1
       </wizard-step>
-      <wizard-step stepTitle='Steptitle 2' selected>
+      <wizard-step stepTitle='Steptitle 2' selectedStep>
         Step 2
       </wizard-step>
       <wizard-step stepTitle='Steptitle 3'>
@@ -48,8 +49,8 @@ describe('SelectedStepDirective', () => {
   });
 
   it('should create an instance', () => {
-    expect(wizardTestFixture.debugElement.query(By.css('wizard-step[selected]'))).toBeTruthy();
-    expect(wizardTestFixture.debugElement.queryAll(By.css('wizard-step[selected]')).length).toBe(1);
+    expect(wizardTestFixture.debugElement.query(By.directive(SelectedStepDirective))).toBeTruthy();
+    expect(wizardTestFixture.debugElement.queryAll(By.directive(SelectedStepDirective)).length).toBe(1);
   });
 
   it('should set optional correctly', () => {
@@ -57,7 +58,7 @@ describe('SelectedStepDirective', () => {
     expect(wizardState.currentStepIndex).toBe(1);
   });
 
-  it('should reset correctly', fakeAsync(() => {
+  it('should reset correctly to the default selected step', fakeAsync(() => {
     navigationMode.goToStep(0);
     tick();
     wizardTestFixture.detectChanges();

--- a/src/directives/selected-step.directive.ts
+++ b/src/directives/selected-step.directive.ts
@@ -2,7 +2,7 @@ import {Directive, Host, OnInit} from '@angular/core';
 import {WizardStep} from '../util/wizard-step.interface';
 
 /**
- * The `selected` directive can be used on a [[WizardStep]] to set it as selected after the wizard initialisation or a reset.
+ * The `selectedStep` directive can be used on a [[WizardStep]] to set it as selected after the wizard initialisation or a reset.
  *
  * ### Syntax
  *
@@ -15,7 +15,7 @@ import {WizardStep} from '../util/wizard-step.interface';
  * @author Marc Arndt
  */
 @Directive({
-  selector: '[selected], [selectedStep]'
+  selector: '[selectedStep]'
 })
 export class SelectedStepDirective implements OnInit {
   /**


### PR DESCRIPTION
Fixes #56, by removing the selectors `reset`, `selected` and `optional`