### PR TITLE
Introduction of an "aw" (archwizard) prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,34 +38,34 @@ export class Module { }
 ```
 
 ## How to use the wizard
-To use this wizard component in an angular project simply add a `wizard` component to the html template of your component:
+To use this wizard component in an angular project simply add a `aw-wizard` component to the html template of your component:
 
 ```html
-<wizard>
-  <wizard-step stepTitle="Title of step 1">
+<aw-wizard>
+  <aw-wizard-step stepTitle="Title of step 1">
     Content of Step 1
-    <button type="button" nextStep>Next Step</button>
-    <button type="button" goToStep="2">Go directly to third Step</button>
-  </wizard-step>
-  <wizard-step stepTitle="Title of step 2" optionalStep>
+    <button type="button" awNextStep>Next Step</button>
+    <button type="button" awGoToStep="2">Go directly to third Step</button>
+  </aw-wizard-step>
+  <aw-wizard-step stepTitle="Title of step 2" awOptionalStep>
     Content of Step 2
-    <button type="button" previousStep>Go to previous step</button>
-    <button type="button" nextStep>Go to next step</button>
-  </wizard-step>
-  <wizard-step stepTitle="Title of step 3">
+    <button type="button" awPreviousStep>Go to previous step</button>
+    <button type="button" awNextStep>Go to next step</button>
+  </aw-wizard-step>
+  <aw-wizard-step stepTitle="Title of step 3">
     Content of Step 3
-    <button type="button" previousStep>Previous Step</button>
+    <button type="button" awPreviousStep>Previous Step</button>
     <button type="button" (click)="finishFunction()">Finish</button>
-  </wizard-step>
-</wizard>
+  </aw-wizard-step>
+</aw-wizard>
 ``` 
 
 ## Components
 
-### \<wizard\>
-The `<wizard>` environment is the environment, in which you define the steps belonging to your wizard.
+### \<aw-wizard\>
+The `<aw-wizard>` environment is the environment, in which you define the steps belonging to your wizard.
 In addition to the contained wizard steps, `ng2-archwizard` enables you to define the location and the layout of the navigation bar inside your wizard.
-To set the location, the layout of the navigation bar and many other settings, you can pass the following parameters to the `wizard` component:
+To set the location, the layout of the navigation bar and many other settings, you can pass the following parameters to the `aw-wizard` component:
 
 #### \[navBarLocation\]
 The location of the navigation bar, contained inside the wizard, can be specified through the `navBarLocation` input value.
@@ -118,7 +118,7 @@ Sometimes it may be necessary to disable navigation via the navigation bar.
 In such a case you can disable navigation via the navigation bar by setting the input `disableNavigationBar` of the wizard component to `true`.
 
 #### Parameter overview
-Possible `<wizard>` parameters:
+Possible `<aw-wizard>` parameters:
 
 | Parameter name         | Possible Values                                                                                       | Default Value |
 | ---------------------- | ----------------------------------------------------------------------------------------------------- | ------------- |
@@ -129,9 +129,9 @@ Possible `<wizard>` parameters:
 | [defaultStepIndex]     | `number`                                                                                              | 0             |
 | [disableNavigationBar] | `boolean`                                                                                             | false         |
 
-### \<wizard-step\>
+### \<aw-wizard-step\>
 `ng2-archwizard` contains two ways to define a wizard step. 
-One of these two ways is by using the `<wizard-step>` component. 
+One of these two ways is by using the `<aw-wizard-step>` component. 
 
 #### \[stepTitle\]
 A wizard step needs to contain a title, which is shown in the navigation bar of the wizard. 
@@ -146,7 +146,7 @@ Be aware, that not all layouts display the symbols. Only the layouts `large-fill
 If you want to add a `2` to the circle in the navigation bar belonging to the second step you can do it like this:
 
 ```html
-<wizard-step stepTitle="Second Step" navigationSymbol="2"></wizard-step>
+<aw-wizard-step stepTitle="Second Step" navigationSymbol="2"></aw-wizard-step>
 ```
 
 In addition to normal symbols it's also possible to use an icon from a font as a symbol.
@@ -163,7 +163,7 @@ For example, if you want to show the icon with the unicode `\f2dd` of [FontAweso
 you need to set the `navigationSymbol` input attribute of the step to `&#xf2dd;` and the `navigationSymbolFontFamily` to `FontAwesome`:
 
 ```html
-<wizard-step stepTitle="Second Step" navigationSymbol="&#xf2dd;" navigationSymbolFontFamily="FontAwesome"></wizard-step>
+<aw-wizard-step stepTitle="Second Step" navigationSymbol="&#xf2dd;" navigationSymbolFontFamily="FontAwesome"></aw-wizard-step>
 ```
 
 #### \[canEnter\]
@@ -186,7 +186,7 @@ This function will then be called whenever an operation has been performed, that
 If you need to call a function to do some initialisation work before entering a wizard step you can add a `stepEnter` attribute to the wizard step environment like this:
 
 ```html
-<wizard-step stepTitle="Second Step" (stepEnter)="enterSecondStep($event)"></wizard-step>
+<aw-wizard-step stepTitle="Second Step" (stepEnter)="enterSecondStep($event)"></aw-wizard-step>
 ```
 
 This leads to the calling of the `enterSecondStep` function when the wizard moves to this step.
@@ -198,11 +198,11 @@ If the user went forwards `MovingDirection.Forwards` will be passed to the funct
 
 #### \(stepExit\)
 Similar to `stepEnter` you can add a `stepExit` attribute to the wizard step environment, if you want to call a function every time a wizard step is exited 
-either by pressing on a component with a `nextStep` or `previousStep` directive, or by a click on the navigation bar. 
+either by pressing on a component with an `awNextStep` or `awPreviousStep` directive, or by a click on the navigation bar. 
 `stepExit`, like `stepEnter` can call the given function with an argument of type `MovingDirection` that signalises in which direction the step was exited.
 
 #### Parameter overview
-Possible `<wizard-step>` parameters:
+Possible `<aw-wizard-step>` parameters:
 
 | Parameter name                | Possible Values                                                                                      | Default Value |
 | ----------------------------- | ---------------------------------------------------------------------------------------------------- | ------------- |
@@ -214,18 +214,18 @@ Possible `<wizard-step>` parameters:
 | (stepEnter)                   | `function(MovingDirection): void`                                                                    | null          |
 | (stepExit)                    | `function(MovingDirection): void`                                                                    | null          |
 
-### \<wizard-completion-step\>
-In addition to the "normal" step component `<wizard-step>` it's also possible to define an optional `<wizard-completion-step>`.
-The `wizard-completion-step` is meant as the final wizard step, which signalises the user, that he or she successfully completed the wizard.
-When a `wizard-completion-step` has been entered by the user, all wizard steps, including the optional steps belonging to the wizard, are marked as completed.
-In addition the user is prevented from leaving the `wizard-completion-step` to another step, once it has been entered. 
+### \<aw-wizard-completion-step\>
+In addition to the "normal" step component `<aw-wizard-step>` it's also possible to define an optional `<aw-wizard-completion-step>`.
+The `aw-wizard-completion-step` is meant as the final wizard step, which signalises the user, that he or she successfully completed the wizard.
+When an `aw-wizard-completion-step` has been entered by the user, all wizard steps, including the optional steps belonging to the wizard, are marked as completed.
+In addition the user is prevented from leaving the `aw-wizard-completion-step` to another step, once it has been entered. 
 
 The given parameters for the wizard completion step are identical to the normal wizard step.
-The only difference is, that it it isn't possible to pass a `(stepExit)` and `[canExit]` parameter to the `wizard-completion-step`, 
+The only difference is, that it it isn't possible to pass a `(stepExit)` and `[canExit]` parameter to the `aw-wizard-completion-step`, 
 because it can't be exited.
 
 #### Parameter overview
-Possible `<wizard-completion-step>` parameters:
+Possible `<aw-wizard-completion-step>` parameters:
 
 | Parameter name                | Possible Values                                                                                      | Default Value |
 | ----------------------------- | ---------------------------------------------------------------------------------------------------- | ------------- |
@@ -237,61 +237,61 @@ Possible `<wizard-completion-step>` parameters:
 
 ## Directives
 
-### \[enableBackLinks\]
-In some cases it may be required that the user is allowed to leave an entered `wizard-completion-step`.
-In such a case you can enable this by adding the directive `[enableBackLinks]` to the `wizard-completion-step`.
+### \[awEnableBackLinks\]
+In some cases it may be required that the user is allowed to leave an entered `aw-wizard-completion-step`.
+In such a case you can enable this by adding the directive `[awEnableBackLinks]` to the `aw-wizard-completion-step`.
 
 ```html
-<wizard-completion-step enableBackLinks>
+<aw-wizard-completion-step awEnableBackLinks>
   Final wizard step
-</wizard-completion-step>
+</aw-wizard-completion-step>
 ```
 
 #### Parameter overview
-Possible `enableBackLinks` parameters:
+Possible `awEnableBackLinks` parameters:
 
 | Parameter name                | Possible Values                                                                                      | Default Value |
 | ----------------------------- | ---------------------------------------------------------------------------------------------------- | ------------- |
 | (stepExit)                    | `function(MovingDirection): void`                                                                    | null          |
 
 
-### \[wizardStepTitle\]
-Sometimes it's not enough to define a title with the `stepTitle` attribute in `<wizard-step>` and `<wizard-completion-step>`.
+### \[awWizardStepTitle\]
+Sometimes it's not enough to define a title with the `stepTitle` attribute in `<aw-wizard-step>` and `<aw-wizard-completion-step>`.
 One example for such a case is, if the title should be written in another font.
 Another example would be if it's desired that the title should be chosen depending on the available width of your screen or window.
 In such cases you may want to specify the html for the title of a wizard step yourself.
-This can be achieved by using the `[wizardStepTitle]` directive inside a wizard step on a `ng-template` component.
+This can be achieved by using the `[awWizardStepTitle]` directive inside a wizard step on a `ng-template` component.
 
 ```html
-<wizard-step (stepEnter)="enterStep($event)">
-  <ng-template wizardStepTitle>
+<aw-wizard-step (stepEnter)="enterStep($event)">
+  <ng-template awWizardStepTitle>
     <span class="hidden-sm-down">Delivery address</span>
     <span class="hidden-md-up">Address</span>
   </ng-template>
-</wizard-step>
+</aw-wizard-step>
 ```
 
-Be aware, that you can only use `[wizardStepTitle]` together with Angular, because `ng-template` was introduced in Angular 4.
+Be aware, that you can only use `[awWizardStepTitle]` together with Angular, because `ng-template` was introduced in Angular 4.
 
-### \[optionalStep\]
+### \[awOptionalStep\]
 If you need to define an optional step, that doesn't need to be done to continue to the next steps, you can define an optional step 
-by adding the `optionalStep` directive to the step you want to declare as optional.
+by adding the `awOptionalStep` directive to the step you want to declare as optional.
 
-### \[selectedStep\]
+### \[awSelectedStep\]
 In some cases it may be a better choice to set the default wizard step not via a static number.
-Another way to set the default wizard step is by using the `selectedStep` directive.
-When attaching the `selectedStep` directive to an arbitrary wizard step, it will be marked as the default wizard step,
+Another way to set the default wizard step is by using the `awSelectedStep` directive.
+When attaching the `awSelectedStep` directive to an arbitrary wizard step, it will be marked as the default wizard step,
 which is shown directly after the wizard startup.
 
-### \[goToStep\]
+### \[awGoToStep\]
 `ng2-archwizard` has three directives, that allow moving between steps.
-These directives are the `previousStep`, `nextStep` and `goToStep` directives.
-The `goToStep` directive needs to receive an argument, that tells the wizard to which step it should change, 
-when the element with the `goToStep` directive has been clicked.
+These directives are the `awPreviousStep`, `asNextStep` and `awGoToStep` directives.
+The `awGoToStep` directive needs to receive an argument, that tells the wizard to which step it should change, 
+when the element with the `awGoToStep` directive has been clicked.
 This argument has to be the zero-based index of the destination step:
 
 ```html
-<button goToStep="2" (finalize)="finalizeStep()">Go directly to the third Step</button>
+<button awGoToStep="2" (finalize)="finalizeStep()">Go directly to the third Step</button>
 ```
 
 In the previous example the button moves the user automatically to the third step, after the user pressed onto it.
@@ -300,20 +300,20 @@ which will set the current as completed and makes it possible to jump over steps
 
 Alternatively to an absolute step index, it's also possible to set the destination wizard step as an offset to the source step:
 ```html
-<button [goToStep]="{stepOffset: 1}" (finalize)="finalizeStep()">Go to the third Step</button>
+<button [awGoToStep]="{stepOffset: 1}" (finalize)="finalizeStep()">Go to the third Step</button>
 ```
 In this example a click on the "Go to the third Step" button will move the user to the next step compared to the step the button belongs to.
 If the button is for example part of the second step, a click on it will move the user to the third step.
-When using offsets it's important to use `[]` around the `goToStep` directive to tell angular that the argument is to be interpreted as javascript.
+When using offsets it's important to use `[]` around the `awGoToStep` directive to tell angular that the argument is to be interpreted as javascript.
 
 In addition to a static value you can also pass a local variable from your component typescript class, 
 that contains to which step a click on the element should change the current step of the wizard. 
 This can be useful if your step transitions depend on some application dependent logic, that changes depending on the user input.
-Here again it's important to use `[]` around the `goToStep` directive to tell angular that the argument is to be interpreted as javascript.  
+Here again it's important to use `[]` around the `awGoToStep` directive to tell angular that the argument is to be interpreted as javascript.  
 
 #### \(preFinalize\)
 Sometimes it's required to bind an event emitter to a specific element, which can perform a step transition. 
-Such an event emitter can be bound to the `(preFinalize)` output of the element, which contains the `goToStep` directive.
+Such an event emitter can be bound to the `(preFinalize)` output of the element, which contains the `awGoToStep` directive.
 This event emitter is then called, directly before the wizard transitions to the given step.
 
 #### \(postFinalize\)
@@ -334,16 +334,16 @@ Possible parameters:
 | (postFinalize)    | `function(): void`                                                | null          |
 | (finalize)        | `function(): void`                                                | null          |
 
-### \[nextStep\]
-By adding a `nextStep` directive to a button or a link inside a step, you automatically add a `onClick` listener to the button or link, that leads to the next step.
+### \[awNextStep\]
+By adding a `awNextStep` directive to a button or a link inside a step, you automatically add a `onClick` listener to the button or link, that leads to the next step.
 This listener will automatically change the currently selected wizard step to the next wizard step after a click on the component.
 
 ```html
-<button (finalize)="finalizeStep()" nextStep>Next Step</button>
+<button (finalize)="finalizeStep()" awNextStep>Next Step</button>
 ```
 
 #### \(finalize\)
-Like the `goToStep` directive the `nextStep` directive provides a `preFinalize`, `postFinalize` and `finalize` output, which are called every time
+Like the `awGoToStep` directive the `awNextStep` directive provides a `preFinalize`, `postFinalize` and `finalize` output, which are called every time
 the current step is successfully exited, by clicking on the element containing the `nextStep` directive.
 
 In the given code snipped above, a click on the button with the text `Next Step`, leads to a call of the `finalize` functions every time, the button has been pressed.
@@ -357,17 +357,17 @@ Possible parameters:
 | (postFinalize)    | `function(): void`                                                | null          |
 | (finalize)        | `function(): void`                                                | null          |
 
-### \[previousStep\]
-By adding a `previousStep` directive to a button or a link, you automatically add a `onClick` listener to the button or link, that changes your wizard to the previous step.
+### \[awPreviousStep\]
+By adding a `awPreviousStep` directive to a button or a link, you automatically add a `onClick` listener to the button or link, that changes your wizard to the previous step.
 This listener will automatically change the currently selected wizard step to the previous wizard step after a click on the component.
 
 ```html
-<button (finalize)="finalizeStep()" previousStep>Previous Step</button>
+<button (finalize)="finalizeStep()" awPreviousStep>Previous Step</button>
 ```
 
 #### \(finalize\)
-Like both the `goToStep` and `nextStep` directives the `previousStep` directives provides a `preFinalize`, `postFinalize` and `finalize` output, which are called every time
-the current step is successfully exited, by clicking on the element containing the `previousStep` directive.
+Like both the `awGoToStep` and `awNextStep` directives the `awPreviousStep` directives provides a `preFinalize`, `postFinalize` and `finalize` output, which are called every time
+the current step is successfully exited, by clicking on the element containing the `awPreviousStep` directive.
 
 #### Parameter overview
 Possible parameters:
@@ -378,24 +378,24 @@ Possible parameters:
 | (postFinalize)    | `function(): void`                                                | null          |
 | (finalize)        | `function(): void`                                                | null          |
 
-### \[wizardStep\]
+### \[awWizardStep\]
 In some cases it may be a good idea to move a wizard step to a custom component.
-This can be done by defining adding the `wizardStep` directive to the component, that contains the wizard step.
+This can be done by defining adding the `awWizardStep` directive to the component, that contains the wizard step.
 
 ```html
-<wizard>
-  <wizard-step stepTitle="Steptitle 1">
+<aw-wizard>
+  <aw-wizard-step stepTitle="Steptitle 1">
     Step 1
-  </wizard-step>
-  <custom-step wizardStep stepTitle="Steptitle 2"></custom-step>
-  <wizard-step stepTitle="Steptitle 3">
+  </aw-wizard-step>
+  <custom-step awWizardStep stepTitle="Steptitle 2"></custom-step>
+  <aw-wizard-step stepTitle="Steptitle 3">
     Step 3
-  </wizard-step>
-</wizard>
+  </aw-wizard-step>
+</aw-wizard>
 ```
 
 #### Parameter overview
-Possible `wizardStep` parameters:
+Possible `awWizardStep` parameters:
 
 | Parameter name                | Possible Values                                                                                      | Default Value |
 | ----------------------------- | ---------------------------------------------------------------------------------------------------- | ------------- |
@@ -407,20 +407,20 @@ Possible `wizardStep` parameters:
 | (stepEnter)                   | `function(MovingDirection): void`                                                                    | null          |
 | (stepExit)                    | `function(MovingDirection): void`                                                                    | null          |
 
-### \[wizardCompletionStep\]
+### \[awWizardCompletionStep\]
 In addition to the possibility of defining a normal wizard step in a custom component, 
 it is also possible to define a wizard completion step in a custom component.
-To define a wizard completion step in a custom component you need to add the `[wizardCompletionStep]` directive to the custom component, 
+To define a wizard completion step in a custom component you need to add the `[awWizardCompletionStep]` directive to the custom component, 
 that contains the wizard completion step.
 
 ```html
-<wizard>
-  <wizard-step stepTitle="Steptitle 1">
+<aw-wizard>
+  <aw-wizard-step stepTitle="Steptitle 1">
     Step 1
-  </wizard-step>
-  <custom-step wizardCompletionStep stepTitle="Completion steptitle">
+  </aw-wizard-step>
+  <custom-step awWizardCompletionStep stepTitle="Completion steptitle">
   </custom-step>
-</wizard>
+</aw-wizard>
 ```
 
 #### Parameter overview
@@ -434,17 +434,17 @@ Possible `wizardCompletionStep` parameters:
 | [canEnter]                    | `function(MovingDirection): boolean` \| `function(MovingDirection): Promise<boolean>` \| `boolean`   | true          |
 | (stepEnter)                   | `function(MovingDirection): void`                                                                    | null          |
 
-### \[resetWizard\]
+### \[awResetWizard\]
 Sometimes it's also required to reset the wizard to its initial state.
-In such a case you can use the `resetWizard` directive.
+In such a case you can use the `awResetWizard` directive.
 This directive can be added to a button or a link for example.
 When clicking on this element, the wizard will automatically reset to its `defaultStepIndex`. 
 
 In addition it's possible to define an `EventEmitter`, that is called when the wizard is being reset.
-This `EventEmitter` can be bound to the `(finalize)` input of the `resetWizard` directive.
+This `EventEmitter` can be bound to the `(finalize)` input of the `awResetWizard` directive.
   
 #### Parameter overview
-Possible `resetWizard` parameters:
+Possible `awResetWizard` parameters:
 
 | Parameter name                | Possible Values                                                                                      | Default Value |
 | ----------------------------- | ---------------------------------------------------------------------------------------------------- | ------------- |
@@ -458,13 +458,13 @@ In such a case you can get the instance of the used wizard component in your own
 public wizard: WizardComponent;
 ```
 
-In case you've created your own wizard step component with the `wizardStep` directive,
+In case you've created your own wizard step component with the `awWizardStep` directive,
 you can inject the state of your wizard in your own component:
 ```typescript
 constructor(private wizardState: WizardState)
 ```
 
-Through the `WizardState` you can access the navigation mode of your wizard, 
+Through the `WizardState` object you can access the navigation mode of your wizard, 
 which allows you to navigate the wizard programmatically.
 Both instances, the wizard state and the navigation mode, can also be obtained from the injected `WizardComponent`.
 

--- a/src/components/wizard-completion-step.component.spec.ts
+++ b/src/components/wizard-completion-step.component.spec.ts
@@ -11,14 +11,14 @@ import {WizardState} from '../navigation/wizard-state.model';
 import {NavigationMode} from '../navigation/navigation-mode.interface';
 
 @Component({
-  selector: 'test-wizard',
+  selector: 'aw-test-wizard',
   template: `
-    <wizard>
-      <wizard-step stepTitle='Steptitle 1' (stepEnter)="enterInto($event, 1)" (stepExit)="exitFrom($event, 1)">Step 1</wizard-step>
-      <wizard-step stepTitle='Steptitle 2' [canExit]="isValid"
-                   optionalStep (stepEnter)="enterInto($event, 2)" (stepExit)="exitFrom($event, 2)">Step 2</wizard-step>
-      <wizard-completion-step stepTitle='Completion steptitle 3' (stepEnter)="enterInto($event, 3)">Step 3</wizard-completion-step>
-    </wizard>
+    <aw-wizard>
+      <aw-wizard-step stepTitle='Steptitle 1' (stepEnter)="enterInto($event, 1)" (stepExit)="exitFrom($event, 1)">Step 1</aw-wizard-step>
+      <aw-wizard-step stepTitle='Steptitle 2' [canExit]="isValid"
+                   awOptionalStep (stepEnter)="enterInto($event, 2)" (stepExit)="exitFrom($event, 2)">Step 2</aw-wizard-step>
+      <aw-wizard-completion-step stepTitle='Completion steptitle 3' (stepEnter)="enterInto($event, 3)">Step 3</aw-wizard-completion-step>
+    </aw-wizard>
   `
 })
 class WizardTestComponent {
@@ -53,13 +53,13 @@ describe('WizardCompletionStepComponent', () => {
     wizardTestFixture.detectChanges();
 
     wizardTest = wizardTestFixture.componentInstance;
-    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    wizardState = wizardTestFixture.debugElement.query(By.css('aw-wizard')).injector.get(WizardState);
     navigationMode = wizardState.navigationMode;
   });
 
   it('should create', () => {
     expect(wizardTest).toBeTruthy();
-    expect(wizardTestFixture.debugElement.queryAll(By.css('wizard-step')).length).toBe(2);
-    expect(wizardTestFixture.debugElement.queryAll(By.css('wizard-completion-step')).length).toBe(1);
+    expect(wizardTestFixture.debugElement.queryAll(By.css('aw-wizard-step')).length).toBe(2);
+    expect(wizardTestFixture.debugElement.queryAll(By.css('aw-wizard-completion-step')).length).toBe(1);
   });
 });

--- a/src/components/wizard-completion-step.component.ts
+++ b/src/components/wizard-completion-step.component.ts
@@ -7,43 +7,43 @@ import {WizardStep} from '../util/wizard-step.interface';
 import {WizardCompletionStep} from '../util/wizard-completion-step.interface';
 
 /**
- * The `wizard-completion-step` component can be used to define a completion/success step at the end of your wizard
- * After a `wizard-completion-step` has been entered, it has the characteristic that the user is blocked from
+ * The `aw-wizard-completion-step` component can be used to define a completion/success step at the end of your wizard
+ * After a `aw-wizard-completion-step` has been entered, it has the characteristic that the user is blocked from
  * leaving it again to a previous step.
- * In addition entering a `wizard-completion-step` automatically sets the `wizard` amd all steps inside the `wizard`
+ * In addition entering a `aw-wizard-completion-step` automatically sets the `aw-wizard` and all steps inside the `aw-wizard`
  * as completed.
  *
  * ### Syntax
  *
  * ```html
- * <wizard-completion-step [stepTitle]="title of the wizard step" [navigationSymbol]="navigation symbol"
+ * <aw-wizard-completion-step [stepTitle]="title of the wizard step" [navigationSymbol]="navigation symbol"
  *    [navigationSymbolFontFamily]="navigation symbol font family"
  *    (stepEnter)="event emitter to be called when the wizard step is entered"
  *    (stepExit)="event emitter to be called when the wizard step is exited">
  *    ...
- * </wizard-completion-step>
+ * </aw-wizard-completion-step>
  * ```
  *
  * ### Example
  *
  * ```html
- * <wizard-completion-step stepTitle="Step 1" navigationSymbol="1">
+ * <aw-wizard-completion-step stepTitle="Step 1" navigationSymbol="1">
  *    ...
- * </wizard-completion-step>
+ * </aw-wizard-completion-step>
  * ```
  *
  * With a navigation symbol from the `font-awesome` font:
  *
  * ```html
- * <wizard-completion-step stepTitle="Step 1" navigationSymbol="&#xf1ba;" navigationSymbolFontFamily="FontAwesome">
+ * <aw-wizard-completion-step stepTitle="Step 1" navigationSymbol="&#xf1ba;" navigationSymbolFontFamily="FontAwesome">
  *    ...
- * </wizard-completion-step>
+ * </aw-wizard-completion-step>
  * ```
  *
  * @author Marc Arndt
  */
 @Component({
-  selector: 'wizard-completion-step',
+  selector: 'aw-wizard-completion-step',
   templateUrl: 'wizard-completion-step.component.html',
   styleUrls: ['wizard-completion-step.component.css'],
   providers: [

--- a/src/components/wizard-navigation-bar.component.html
+++ b/src/components/wizard-navigation-bar.component.html
@@ -13,7 +13,7 @@
         navigable: isNavigable(step)
   }">
     <div>
-      <a [goToStep]="step">
+      <a [awGoToStep]="step">
         <ng-container *ngIf="step.stepTitleTemplate" [ngTemplateOutlet]="step.stepTitleTemplate.templateRef"></ng-container>
         <ng-container *ngIf="!step.stepTitleTemplate">{{step.stepTitle}}</ng-container>
       </a>

--- a/src/components/wizard-navigation-bar.component.spec.ts
+++ b/src/components/wizard-navigation-bar.component.spec.ts
@@ -8,13 +8,13 @@ import {NavigationMode} from '../navigation/navigation-mode.interface';
 import {WizardState} from '../navigation/wizard-state.model';
 
 @Component({
-  selector: 'test-wizard',
+  selector: 'aw-test-wizard',
   template: `
-    <wizard>
-      <wizard-step stepTitle='Steptitle 1'>Step 1</wizard-step>
-      <wizard-step stepTitle='Steptitle 2' optionalStep>Step 2</wizard-step>
-      <wizard-step stepTitle='Steptitle 3'>Step 3</wizard-step>
-    </wizard>
+    <aw-wizard>
+      <aw-wizard-step stepTitle='Steptitle 1'>Step 1</aw-wizard-step>
+      <aw-wizard-step stepTitle='Steptitle 2' awOptionalStep>Step 2</aw-wizard-step>
+      <aw-wizard-step stepTitle='Steptitle 3'>Step 3</aw-wizard-step>
+    </aw-wizard>
   `
 })
 class WizardTestComponent {
@@ -41,22 +41,22 @@ describe('WizardNavigationBarComponent', () => {
     wizardTestFixture.detectChanges();
 
     wizardTest = wizardTestFixture.componentInstance;
-    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    wizardState = wizardTestFixture.debugElement.query(By.css('aw-wizard')).injector.get(WizardState);
     navigationMode = wizardState.navigationMode;
   });
 
   it('should create', () => {
     expect(wizardTest).toBeTruthy();
-    expect(wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'))).toBeTruthy();
+    expect(wizardTestFixture.debugElement.query(By.css('aw-wizard-navigation-bar'))).toBeTruthy();
   });
 
   it('should create only one navigation bar', () => {
     expect(wizardTest).toBeTruthy();
-    expect(wizardTestFixture.debugElement.queryAll(By.css('wizard-navigation-bar')).length).toBe(1);
+    expect(wizardTestFixture.debugElement.queryAll(By.css('aw-wizard-navigation-bar')).length).toBe(1);
   });
 
   it('should show the initial step correctly', () => {
-    const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
+    const navBar = wizardTestFixture.debugElement.query(By.css('aw-wizard-navigation-bar'));
 
     const allLi = navBar.queryAll(By.css('li'));
 
@@ -89,7 +89,7 @@ describe('WizardNavigationBarComponent', () => {
   });
 
   it('should show the second step correctly', fakeAsync(() => {
-    const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
+    const navBar = wizardTestFixture.debugElement.query(By.css('aw-wizard-navigation-bar'));
 
     // go to second step
     navigationMode.goToNextStep();
@@ -128,7 +128,7 @@ describe('WizardNavigationBarComponent', () => {
   }));
 
   it('should show the third step correctly', fakeAsync(() => {
-    const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
+    const navBar = wizardTestFixture.debugElement.query(By.css('aw-wizard-navigation-bar'));
 
     // go to second step
     navigationMode.goToNextStep();
@@ -173,7 +173,7 @@ describe('WizardNavigationBarComponent', () => {
   }));
 
   it('should show the third step correctly, after jump from first to third step', fakeAsync(() => {
-    const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
+    const navBar = wizardTestFixture.debugElement.query(By.css('aw-wizard-navigation-bar'));
 
     // go to third step and jump over the optional second step
     navigationMode.goToStep(2);
@@ -213,7 +213,7 @@ describe('WizardNavigationBarComponent', () => {
   }));
 
   it('should show the first step correctly, after going back from the second step to the first step', fakeAsync(() => {
-    const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
+    const navBar = wizardTestFixture.debugElement.query(By.css('aw-wizard-navigation-bar'));
 
     // go to second step
     navigationMode.goToNextStep();
@@ -257,7 +257,7 @@ describe('WizardNavigationBarComponent', () => {
 
   it('should show the first step correctly, after first jumping from the first to the third step ' +
     'and then back from the third step to the first step', fakeAsync(() => {
-    const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
+    const navBar = wizardTestFixture.debugElement.query(By.css('aw-wizard-navigation-bar'));
 
     // go to third step, by jumping over the optional step
     navigationMode.goToStep(2);
@@ -301,7 +301,7 @@ describe('WizardNavigationBarComponent', () => {
 
   it('should show the second step correctly, after first jumping from the first to the third step ' +
     'and then back from the third step to the second step', fakeAsync(() => {
-    const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
+    const navBar = wizardTestFixture.debugElement.query(By.css('aw-wizard-navigation-bar'));
 
     // go to third step, by jumping over the optional step
     navigationMode.goToStep(2);
@@ -345,7 +345,7 @@ describe('WizardNavigationBarComponent', () => {
   }));
 
   it('should disable navigation through the navigation bar correctly', fakeAsync(() => {
-    const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
+    const navBar = wizardTestFixture.debugElement.query(By.css('aw-wizard-navigation-bar'));
 
     wizardState.disableNavigationBar = true;
 
@@ -457,14 +457,14 @@ describe('WizardNavigationBarComponent', () => {
   });
 
   it('should use the \"small\" layout when no navigation bar layout is specified', () => {
-    const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
+    const navBar = wizardTestFixture.debugElement.query(By.css('aw-wizard-navigation-bar'));
 
     expect(navBar.classes).toEqual({ 'horizontal': true, 'vertical': false, 'small': true,
       'large-filled': false, 'large-filled-symbols': false, 'large-empty': false, 'large-empty-symbols': false });
   });
 
   it('should use the \"small\" layout when it is specified', () => {
-    const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
+    const navBar = wizardTestFixture.debugElement.query(By.css('aw-wizard-navigation-bar'));
 
     wizardTest.wizard.navBarLayout = 'small';
     wizardTestFixture.detectChanges();
@@ -474,7 +474,7 @@ describe('WizardNavigationBarComponent', () => {
   });
 
   it('should use the \"large-filled\" layout when it is specified', () => {
-    const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
+    const navBar = wizardTestFixture.debugElement.query(By.css('aw-wizard-navigation-bar'));
 
     wizardTest.wizard.navBarLayout = 'large-filled';
     wizardTestFixture.detectChanges();
@@ -484,7 +484,7 @@ describe('WizardNavigationBarComponent', () => {
   });
 
   it('should use the \"large-empty\" layout when it is specified', () => {
-    const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
+    const navBar = wizardTestFixture.debugElement.query(By.css('aw-wizard-navigation-bar'));
 
     wizardTest.wizard.navBarLayout = 'large-empty';
     wizardTestFixture.detectChanges();
@@ -494,7 +494,7 @@ describe('WizardNavigationBarComponent', () => {
   });
 
   it('should use the \"large-filled-symbols\" layout when it is specified', () => {
-    const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
+    const navBar = wizardTestFixture.debugElement.query(By.css('aw-wizard-navigation-bar'));
 
     wizardTest.wizard.navBarLayout = 'large-filled-symbols';
     wizardTestFixture.detectChanges();
@@ -504,7 +504,7 @@ describe('WizardNavigationBarComponent', () => {
   });
 
   it('should use the \"large-empty-symbols\" layout when it is specified', () => {
-    const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
+    const navBar = wizardTestFixture.debugElement.query(By.css('aw-wizard-navigation-bar'));
 
     wizardTest.wizard.navBarLayout = 'large-empty-symbols';
     wizardTestFixture.detectChanges();
@@ -514,7 +514,7 @@ describe('WizardNavigationBarComponent', () => {
   });
 
   it('should show the correct step titles', () => {
-    let navigationLinks = wizardTestFixture.debugElement.queryAll(By.css('wizard-navigation-bar ul li a'));
+    let navigationLinks = wizardTestFixture.debugElement.queryAll(By.css('aw-wizard-navigation-bar ul li a'));
 
     expect(navigationLinks.length).toBe(3);
     expect(navigationLinks[0].nativeElement.innerText).toBe('STEPTITLE 1');
@@ -526,7 +526,7 @@ describe('WizardNavigationBarComponent', () => {
     wizardTest.wizard.navBarDirection = 'right-to-left';
     wizardTestFixture.detectChanges();
 
-    let navigationLinks = wizardTestFixture.debugElement.queryAll(By.css('wizard-navigation-bar ul li a'));
+    let navigationLinks = wizardTestFixture.debugElement.queryAll(By.css('aw-wizard-navigation-bar ul li a'));
 
     expect(navigationLinks.length).toBe(3);
     expect(navigationLinks[0].nativeElement.innerText).toBe('STEPTITLE 3');

--- a/src/components/wizard-navigation-bar.component.ts
+++ b/src/components/wizard-navigation-bar.component.ts
@@ -4,20 +4,20 @@ import {WizardState} from '../navigation/wizard-state.model';
 import {NavigationMode} from '../navigation/navigation-mode.interface';
 
 /**
- * The `wizard-navigation-bar` component contains the navigation bar inside a [[WizardComponent]].
+ * The `aw-wizard-navigation-bar` component contains the navigation bar inside a [[WizardComponent]].
  * To correctly display the navigation bar, it's required to set the right css classes for the navigation bar,
  * otherwise it will look like a normal `ul` component.
  *
  * ### Syntax
  *
  * ```html
- * <wizard-navigation-bar></wizard-navigation-bar>
+ * <aw-wizard-navigation-bar></aw-wizard-navigation-bar>
  * ```
  *
  * @author Marc Arndt
  */
 @Component({
-  selector: 'wizard-navigation-bar',
+  selector: 'aw-wizard-navigation-bar',
   templateUrl: 'wizard-navigation-bar.component.html',
   styleUrls: ['wizard-navigation-bar.component.horizontal.less', 'wizard-navigation-bar.component.vertical.less']
 })

--- a/src/components/wizard-step.component.spec.ts
+++ b/src/components/wizard-step.component.spec.ts
@@ -8,14 +8,14 @@ import {NavigationMode} from '../navigation/navigation-mode.interface';
 import {WizardState} from '../navigation/wizard-state.model';
 
 @Component({
-  selector: 'test-wizard',
+  selector: 'aw-test-wizard',
   template: `
-    <wizard>
-      <wizard-step stepTitle='Steptitle 1' (stepEnter)="enterInto($event, 1)" (stepExit)="exitFrom($event, 1)">Step 1</wizard-step>
-      <wizard-step stepTitle='Steptitle 2' [canExit]="isValid"
-                   optionalStep (stepEnter)="enterInto($event, 2)" (stepExit)="exitFrom($event, 2)">Step 2</wizard-step>
-      <wizard-step stepTitle='Steptitle 3' (stepEnter)="enterInto($event, 3)" (stepExit)="exitFrom($event, 3)">Step 3</wizard-step>
-    </wizard>
+    <aw-wizard>
+      <aw-wizard-step stepTitle='Steptitle 1' (stepEnter)="enterInto($event, 1)" (stepExit)="exitFrom($event, 1)">Step 1</aw-wizard-step>
+      <aw-wizard-step stepTitle='Steptitle 2' [canExit]="isValid"
+                   awOptionalStep (stepEnter)="enterInto($event, 2)" (stepExit)="exitFrom($event, 2)">Step 2</aw-wizard-step>
+      <aw-wizard-step stepTitle='Steptitle 3' (stepEnter)="enterInto($event, 3)" (stepExit)="exitFrom($event, 3)">Step 3</aw-wizard-step>
+    </aw-wizard>
   `
 })
 class WizardTestComponent {
@@ -51,12 +51,12 @@ describe('WizardStepComponent', () => {
     wizardTestFixture.detectChanges();
 
     wizardTest = wizardTestFixture.componentInstance;
-    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    wizardState = wizardTestFixture.debugElement.query(By.css('aw-wizard')).injector.get(WizardState);
     navigationMode = wizardState.navigationMode;
   });
 
   it('should create', () => {
     expect(wizardTest).toBeTruthy();
-    expect(wizardTestFixture.debugElement.queryAll(By.css('wizard-step')).length).toBe(3);
+    expect(wizardTestFixture.debugElement.queryAll(By.css('aw-wizard-step')).length).toBe(3);
   });
 });

--- a/src/components/wizard-step.component.ts
+++ b/src/components/wizard-step.component.ts
@@ -2,29 +2,29 @@ import {Component, forwardRef} from '@angular/core';
 import {WizardStep} from '../util/wizard-step.interface';
 
 /**
- * The `wizard-step` component is used to define a normal step inside a wizard.
+ * The `aw-wizard-step` component is used to define a normal step inside a wizard.
  *
  * ### Syntax
  *
  * With `stepTitle` input:
  *
  * ```html
- * <wizard-step [stepTitle]="step title" [navigationSymbol]="symbol" [navigationSymbolFontFamily]="font-family"
+ * <aw-wizard-step [stepTitle]="step title" [navigationSymbol]="symbol" [navigationSymbolFontFamily]="font-family"
  *    [canExit]="deciding function" (stepEnter)="enter function" (stepExit)="exit function">
  *    ...
- * </wizard-step>
+ * </aw-wizard-step>
  * ```
  *
- * With `wizardStepTitle` directive:
+ * With `awWizardStepTitle` directive:
  *
  * ```html
- * <wizard-step [navigationSymbol]="symbol" [navigationSymbolFontFamily]="font-family"
+ * <aw-wizard-step [navigationSymbol]="symbol" [navigationSymbolFontFamily]="font-family"
  *    [canExit]="deciding function" (stepEnter)="enter function" (stepExit)="exit function">
- *    <ng-template wizardStepTitle>
+ *    <ng-template awWizardStepTitle>
  *        step title
  *    </ng-template>
  *    ...
- * </wizard-step>
+ * </aw-wizard-step>
  * ```
  *
  * ### Example
@@ -32,25 +32,25 @@ import {WizardStep} from '../util/wizard-step.interface';
  * With `stepTitle` input:
  *
  * ```html
- * <wizard-step stepTitle="Address information" navigationSymbol="&#xf1ba;" navigationSymbolFontFamily="FontAwesome">
+ * <aw-wizard-step stepTitle="Address information" navigationSymbol="&#xf1ba;" navigationSymbolFontFamily="FontAwesome">
  *    ...
- * </wizard-step>
+ * </aw-wizard-step>
  * ```
  *
- * With `wizardStepTitle` directive:
+ * With `awWizardStepTitle` directive:
  *
  * ```html
- * <wizard-step navigationSymbol="&#xf1ba;" navigationSymbolFontFamily="FontAwesome">
- *    <ng-template wizardStepTitle>
+ * <aw-wizard-step navigationSymbol="&#xf1ba;" navigationSymbolFontFamily="FontAwesome">
+ *    <ng-template awWizardStepTitle>
  *        Address information
  *    </ng-template>
- * </wizard-step>
+ * </aw-wizard-step>
  * ```
  *
  * @author Marc Arndt
  */
 @Component({
-  selector: 'wizard-step',
+  selector: 'aw-wizard-step',
   templateUrl: 'wizard-step.component.html',
   styleUrls: ['wizard-step.component.css'],
   providers: [

--- a/src/components/wizard.component.html
+++ b/src/components/wizard.component.html
@@ -1,4 +1,4 @@
-<wizard-navigation-bar
+<aw-wizard-navigation-bar
   [direction]="navBarDirection"
   *ngIf="navBarLocation == 'top' || navBarLocation == 'left'"
   [ngClass]="{
@@ -10,7 +10,7 @@
     'large-empty': navBarLayout == 'large-empty',
     'large-empty-symbols': navBarLayout == 'large-empty-symbols'
   }">
-</wizard-navigation-bar>
+</aw-wizard-navigation-bar>
 
 <div [ngClass]="{
   'wizard-steps': true,
@@ -20,7 +20,7 @@
   <ng-content></ng-content>
 </div>
 
-<wizard-navigation-bar
+<aw-wizard-navigation-bar
   [direction]="navBarDirection"
   *ngIf="navBarLocation == 'bottom' || navBarLocation == 'right'"
   [ngClass]="{
@@ -32,4 +32,4 @@
     'large-empty': navBarLayout == 'large-empty',
     'large-empty-symbols': navBarLayout == 'large-empty-symbols'
   }">
-</wizard-navigation-bar>
+</aw-wizard-navigation-bar>

--- a/src/components/wizard.component.spec.ts
+++ b/src/components/wizard.component.spec.ts
@@ -7,13 +7,13 @@ import {WizardState} from '../navigation/wizard-state.model';
 import {NavigationMode} from '../navigation/navigation-mode.interface';
 
 @Component({
-  selector: 'test-wizard',
+  selector: 'aw-test-wizard',
   template: `
-    <wizard>
-      <wizard-step stepTitle='Steptitle 1'>Step 1</wizard-step>
-      <wizard-step stepTitle='Steptitle 2'>Step 2</wizard-step>
-      <wizard-step stepTitle='Steptitle 3'>Step 3</wizard-step>
-    </wizard>
+    <aw-wizard>
+      <aw-wizard-step stepTitle='Steptitle 1'>Step 1</aw-wizard-step>
+      <aw-wizard-step stepTitle='Steptitle 2'>Step 2</aw-wizard-step>
+      <aw-wizard-step stepTitle='Steptitle 3'>Step 3</aw-wizard-step>
+    </aw-wizard>
   `
 })
 class WizardTestComponent {
@@ -40,7 +40,7 @@ describe('WizardComponent', () => {
     wizardTestFixture.detectChanges();
 
     wizardTest = wizardTestFixture.componentInstance;
-    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    wizardState = wizardTestFixture.debugElement.query(By.css('aw-wizard')).injector.get(WizardState);
     navigationMode = wizardState.navigationMode;
   });
 
@@ -48,7 +48,7 @@ describe('WizardComponent', () => {
     expect(wizardTest).toBeTruthy();
     expect(wizardTest.wizard).toBeTruthy();
 
-    expect(wizardTestFixture.debugElement.query(By.css('wizard'))).toBeTruthy();
+    expect(wizardTestFixture.debugElement.query(By.css('aw-wizard'))).toBeTruthy();
     expect(wizardTest.wizard.model).toBeTruthy();
     expect(wizardTest.wizard.navigation).toBeTruthy();
 
@@ -57,15 +57,15 @@ describe('WizardComponent', () => {
   });
 
   it('should contain navigation bar at the correct position in default navBarLocation mode', () => {
-    const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
-    const wizard = wizardTestFixture.debugElement.query(By.css('wizard'));
+    const navBar = wizardTestFixture.debugElement.query(By.css('aw-wizard-navigation-bar'));
+    const wizard = wizardTestFixture.debugElement.query(By.css('aw-wizard'));
     const wizardStepsDiv = wizardTestFixture.debugElement.query(By.css('div.wizard-steps'));
 
     // check default: the navbar should be at the top of the wizard if no navBarLocation was set
     expect(navBar).toBeTruthy();
-    expect(wizardTestFixture.debugElement.query(By.css('wizard')).children.length).toBe(2);
-    expect(wizardTestFixture.debugElement.query(By.css('wizard > :first-child')).name).toBe('wizard-navigation-bar');
-    expect(wizardTestFixture.debugElement.query(By.css('wizard > :last-child')).name).toBe('div');
+    expect(wizardTestFixture.debugElement.query(By.css('aw-wizard')).children.length).toBe(2);
+    expect(wizardTestFixture.debugElement.query(By.css('aw-wizard > :first-child')).name).toBe('aw-wizard-navigation-bar');
+    expect(wizardTestFixture.debugElement.query(By.css('aw-wizard > :last-child')).name).toBe('div');
 
     expect(navBar.classes).toEqual({ 'horizontal': true, 'vertical': false, 'small': true,
       'large-filled': false, 'large-filled-symbols': false, 'large-empty': false, 'large-empty-symbols': false });
@@ -77,15 +77,15 @@ describe('WizardComponent', () => {
     wizardTest.wizard.navBarLocation = 'top';
     wizardTestFixture.detectChanges();
 
-    const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
-    const wizard = wizardTestFixture.debugElement.query(By.css('wizard'));
+    const navBar = wizardTestFixture.debugElement.query(By.css('aw-wizard-navigation-bar'));
+    const wizard = wizardTestFixture.debugElement.query(By.css('aw-wizard'));
     const wizardStepsDiv = wizardTestFixture.debugElement.query(By.css('div.wizard-steps'));
 
     // check default: the navbar should be at the top of the wizard if no navBarLocation was set
     expect(navBar).toBeTruthy();
-    expect(wizardTestFixture.debugElement.query(By.css('wizard')).children.length).toBe(2);
-    expect(wizardTestFixture.debugElement.query(By.css('wizard > :first-child')).name).toBe('wizard-navigation-bar');
-    expect(wizardTestFixture.debugElement.query(By.css('wizard > :last-child')).name).toBe('div');
+    expect(wizardTestFixture.debugElement.query(By.css('aw-wizard')).children.length).toBe(2);
+    expect(wizardTestFixture.debugElement.query(By.css('aw-wizard > :first-child')).name).toBe('aw-wizard-navigation-bar');
+    expect(wizardTestFixture.debugElement.query(By.css('aw-wizard > :last-child')).name).toBe('div');
 
     expect(navBar.classes).toEqual({ 'horizontal': true, 'vertical': false, 'small': true,
       'large-filled': false, 'large-filled-symbols': false, 'large-empty': false, 'large-empty-symbols': false });
@@ -97,15 +97,15 @@ describe('WizardComponent', () => {
     wizardTest.wizard.navBarLocation = 'left';
     wizardTestFixture.detectChanges();
 
-    const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
-    const wizard = wizardTestFixture.debugElement.query(By.css('wizard'));
+    const navBar = wizardTestFixture.debugElement.query(By.css('aw-wizard-navigation-bar'));
+    const wizard = wizardTestFixture.debugElement.query(By.css('aw-wizard'));
     const wizardStepsDiv = wizardTestFixture.debugElement.query(By.css('div.wizard-steps'));
 
     // check default: the navbar should be at the top of the wizard if no navBarLocation was set
     expect(navBar).toBeTruthy();
-    expect(wizardTestFixture.debugElement.query(By.css('wizard')).children.length).toBe(2);
-    expect(wizardTestFixture.debugElement.query(By.css('wizard > :first-child')).name).toBe('wizard-navigation-bar');
-    expect(wizardTestFixture.debugElement.query(By.css('wizard > :last-child')).name).toBe('div');
+    expect(wizardTestFixture.debugElement.query(By.css('aw-wizard')).children.length).toBe(2);
+    expect(wizardTestFixture.debugElement.query(By.css('aw-wizard > :first-child')).name).toBe('aw-wizard-navigation-bar');
+    expect(wizardTestFixture.debugElement.query(By.css('aw-wizard > :last-child')).name).toBe('div');
 
     expect(navBar.classes).toEqual({ 'horizontal': false, 'vertical': true, 'small': true,
       'large-filled': false, 'large-filled-symbols': false, 'large-empty': false, 'large-empty-symbols': false });
@@ -117,15 +117,15 @@ describe('WizardComponent', () => {
     wizardTest.wizard.navBarLocation = 'bottom';
     wizardTestFixture.detectChanges();
 
-    const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
-    const wizard = wizardTestFixture.debugElement.query(By.css('wizard'));
+    const navBar = wizardTestFixture.debugElement.query(By.css('aw-wizard-navigation-bar'));
+    const wizard = wizardTestFixture.debugElement.query(By.css('aw-wizard'));
     const wizardStepsDiv = wizardTestFixture.debugElement.query(By.css('div.wizard-steps'));
 
     // check default: the navbar should be at the top of the wizard if no navBarLocation was set
     expect(navBar).toBeTruthy();
-    expect(wizardTestFixture.debugElement.query(By.css('wizard')).children.length).toBe(2);
-    expect(wizardTestFixture.debugElement.query(By.css('wizard > :first-child')).name).toBe('div');
-    expect(wizardTestFixture.debugElement.query(By.css('wizard > :last-child')).name).toBe('wizard-navigation-bar');
+    expect(wizardTestFixture.debugElement.query(By.css('aw-wizard')).children.length).toBe(2);
+    expect(wizardTestFixture.debugElement.query(By.css('aw-wizard > :first-child')).name).toBe('div');
+    expect(wizardTestFixture.debugElement.query(By.css('aw-wizard > :last-child')).name).toBe('aw-wizard-navigation-bar');
 
     expect(navBar.classes).toEqual({ 'horizontal': true, 'vertical': false, 'small': true,
       'large-filled': false, 'large-filled-symbols': false, 'large-empty': false, 'large-empty-symbols': false });
@@ -137,15 +137,15 @@ describe('WizardComponent', () => {
     wizardTest.wizard.navBarLocation = 'right';
     wizardTestFixture.detectChanges();
 
-    const navBar = wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'));
-    const wizard = wizardTestFixture.debugElement.query(By.css('wizard'));
+    const navBar = wizardTestFixture.debugElement.query(By.css('aw-wizard-navigation-bar'));
+    const wizard = wizardTestFixture.debugElement.query(By.css('aw-wizard'));
     const wizardStepsDiv = wizardTestFixture.debugElement.query(By.css('div.wizard-steps'));
 
     // check default: the navbar should be at the top of the wizard if no navBarLocation was set
     expect(navBar).toBeTruthy();
-    expect(wizardTestFixture.debugElement.query(By.css('wizard')).children.length).toBe(2);
-    expect(wizardTestFixture.debugElement.query(By.css('wizard > :first-child')).name).toBe('div');
-    expect(wizardTestFixture.debugElement.query(By.css('wizard > :last-child')).name).toBe('wizard-navigation-bar');
+    expect(wizardTestFixture.debugElement.query(By.css('aw-wizard')).children.length).toBe(2);
+    expect(wizardTestFixture.debugElement.query(By.css('aw-wizard > :first-child')).name).toBe('div');
+    expect(wizardTestFixture.debugElement.query(By.css('aw-wizard > :last-child')).name).toBe('aw-wizard-navigation-bar');
 
     expect(navBar.classes).toEqual({ 'horizontal': false, 'vertical': true, 'small': true,
       'large-filled': false, 'large-filled-symbols': false, 'large-empty': false, 'large-empty-symbols': false });

--- a/src/components/wizard.component.ts
+++ b/src/components/wizard.component.ts
@@ -4,15 +4,15 @@ import {WizardState} from '../navigation/wizard-state.model';
 import {NavigationMode} from '../navigation/navigation-mode.interface';
 
 /**
- * The `wizard` component defines the root component of a wizard.
- * Through the setting of input parameters for the `wizard` component it's possible to change the location and size
+ * The `aw-wizard` component defines the root component of a wizard.
+ * Through the setting of input parameters for the `aw-wizard` component it's possible to change the location and size
  * of its navigation bar.
  *
  * ### Syntax
  * ```html
- * <wizard [navBarLocation]="location of navigation bar" [navBarLayout]="layout of navigation bar">
+ * <aw-wizard [navBarLocation]="location of navigation bar" [navBarLayout]="layout of navigation bar">
  *     ...
- * </wizard>
+ * </aw-wizard>
  * ```
  *
  * ### Example
@@ -20,26 +20,26 @@ import {NavigationMode} from '../navigation/navigation-mode.interface';
  * Without completion step:
  *
  * ```html
- * <wizard navBarLocation="top" navBarLayout="small">
- *     <wizard-step>...</wizard-step>
- *     <wizard-step>...</wizard-step>
- * </wizard>
+ * <aw-wizard navBarLocation="top" navBarLayout="small">
+ *     <aw-wizard-step>...</aw-wizard-step>
+ *     <aw-wizard-step>...</aw-wizard-step>
+ * </aw-wizard>
  * ```
  *
  * With completion step:
  *
  * ```html
- * <wizard navBarLocation="top" navBarLayout="small">
- *     <wizard-step>...</wizard-step>
- *     <wizard-step>...</wizard-step>
- *     <wizard-completion-step>...</wizard-completion-step>
- * </wizard>
+ * <aw-wizard navBarLocation="top" navBarLayout="small">
+ *     <aw-wizard-step>...</aw-wizard-step>
+ *     <aw-wizard-step>...</aw-wizard-step>
+ *     <aw-wizard-completion-step>...</aw-wizard-completion-step>
+ * </aw-wizard>
  * ```
  *
  * @author Marc Arndt
  */
 @Component({
-  selector: 'wizard',
+  selector: 'aw-wizard',
   templateUrl: 'wizard.component.html',
   styleUrls: ['wizard.component.less'],
   providers: [WizardState]

--- a/src/directives/enable-back-links.directive.spec.ts
+++ b/src/directives/enable-back-links.directive.spec.ts
@@ -10,21 +10,21 @@ import {WizardState} from '../navigation/wizard-state.model';
 import {NavigationMode} from '../navigation/navigation-mode.interface';
 
 @Component({
-  selector: 'test-wizard',
+  selector: 'aw-test-wizard',
   template: `
-    <wizard>
-      <wizard-step stepTitle='Steptitle 1' (stepEnter)="enterInto($event, 1)" (stepExit)="exitFrom($event, 1)">
+    <aw-wizard>
+      <aw-wizard-step stepTitle='Steptitle 1' (stepEnter)="enterInto($event, 1)" (stepExit)="exitFrom($event, 1)">
         Step 1
-      </wizard-step>
-      <wizard-step stepTitle='Steptitle 2' [canExit]="isValid"
-                   optionalStep (stepEnter)="enterInto($event, 2)" (stepExit)="exitFrom($event, 2)">
+      </aw-wizard-step>
+      <aw-wizard-step stepTitle='Steptitle 2' [canExit]="isValid"
+                   awOptionalStep (stepEnter)="enterInto($event, 2)" (stepExit)="exitFrom($event, 2)">
         Step 2
-      </wizard-step>
-      <wizard-completion-step enableBackLinks stepTitle='Completion steptitle 3' (stepEnter)="enterInto($event, 3)"
+      </aw-wizard-step>
+      <aw-wizard-completion-step awEnableBackLinks stepTitle='Completion steptitle 3' (stepEnter)="enterInto($event, 3)"
                               (stepExit)="completionStepExit($event, 3)">
         Step 3
-      </wizard-completion-step>
-    </wizard>
+      </aw-wizard-completion-step>
+    </aw-wizard>
   `
 })
 class WizardTestComponent {
@@ -62,14 +62,14 @@ describe('EnableBackLinksDirective', () => {
     wizardTestFixture.detectChanges();
 
     wizardTest = wizardTestFixture.componentInstance;
-    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    wizardState = wizardTestFixture.debugElement.query(By.css('aw-wizard')).injector.get(WizardState);
     navigationMode = wizardState.navigationMode;
   });
 
   it('should create', () => {
     expect(wizardTest).toBeTruthy();
-    expect(wizardTestFixture.debugElement.queryAll(By.css('wizard-step')).length).toBe(2);
-    expect(wizardTestFixture.debugElement.queryAll(By.css('wizard-completion-step')).length).toBe(1);
+    expect(wizardTestFixture.debugElement.queryAll(By.css('aw-wizard-step')).length).toBe(2);
+    expect(wizardTestFixture.debugElement.queryAll(By.css('aw-wizard-completion-step')).length).toBe(1);
   });
 
   it('should be able to leave the completion step', fakeAsync(() => {

--- a/src/directives/enable-back-links.directive.ts
+++ b/src/directives/enable-back-links.directive.ts
@@ -3,28 +3,28 @@ import {MovingDirection} from '../util/moving-direction.enum';
 import {WizardCompletionStep} from '../util/wizard-completion-step.interface';
 
 /**
- * The `enableBackLinks` directive can be used to allow the user to leave a [[WizardCompletionStep]] after is has been entered.
+ * The `awEnableBackLinks` directive can be used to allow the user to leave a [[WizardCompletionStep]] after is has been entered.
  *
  * ### Syntax
  *
  * ```html
- * <wizard-completion-step enableBackLinks (stepExit)="exit function">
+ * <aw-wizard-completion-step awEnableBackLinks (stepExit)="exit function">
  *     ...
- * </wizard-completion-step>
+ * </aw-wizard-completion-step>
  * ```
  *
  * ### Example
  *
  * ```html
- * <wizard-completion-step stepTitle="Final step" enableBackLinks>
+ * <aw-wizard-completion-step stepTitle="Final step" awEnableBackLinks>
  *     ...
- * </wizard-completion-step>
+ * </aw-wizard-completion-step>
  * ```
  *
  * @author Marc Arndt
  */
 @Directive({
-  selector: '[enableBackLinks]'
+  selector: '[awEnableBackLinks]'
 })
 export class EnableBackLinksDirective implements OnInit {
   /**

--- a/src/directives/go-to-step.directive.spec.ts
+++ b/src/directives/go-to-step.directive.spec.ts
@@ -195,16 +195,16 @@ describe('GoToStepDirective', () => {
     expect(wizardTest.eventLog).toEqual(['finalize 1', 'finalize 3']);
   }));
 
-  it('should throw an error when using an invalid destinationStep value', fakeAsync(() => {
+  it('should throw an error when using an invalid targetStep value', fakeAsync(() => {
     const invalidGoToAttribute = wizardTestFixture.debugElement
       .query(By.css('aw-wizard-step[stepTitle="Steptitle 2"]'))
       .queryAll(By.directive(GoToStepDirective))[1].injector.get(GoToStepDirective) as GoToStepDirective;
 
     expect(() => invalidGoToAttribute.destinationStep)
-      .toThrow(new Error(`Input 'goToStep' is neither a WizardStep, StepOffset, number or string`));
+      .toThrow(new Error(`Input 'targetStep' is neither a WizardStep, StepOffset, number or string`));
   }));
 
-  it('should return correct destination step for correct destinationStep values', fakeAsync(() => {
+  it('should return correct destination step for correct targetStep values', fakeAsync(() => {
     const firstGoToAttribute = wizardTestFixture.debugElement
       .query(By.css('aw-wizard-navigation-bar'))
       .queryAll(By.directive(GoToStepDirective))[0].injector.get(GoToStepDirective) as GoToStepDirective;

--- a/src/directives/go-to-step.directive.spec.ts
+++ b/src/directives/go-to-step.directive.spec.ts
@@ -10,25 +10,25 @@ import {WizardState} from '../navigation/wizard-state.model';
 import {NavigationMode} from '../navigation/navigation-mode.interface';
 
 @Component({
-  selector: 'test-wizard',
+  selector: 'aw-test-wizard',
   template: `
-    <wizard>
-      <wizard-step stepTitle='Steptitle 1' [canExit]="canExit">
+    <aw-wizard>
+      <aw-wizard-step stepTitle='Steptitle 1' [canExit]="canExit">
         Step 1
-        <button type="button" goToStep="0" (preFinalize)="finalizeStep(1)">Stay at this step</button>
-        <button type="button" [goToStep]="goToSecondStep" (preFinalize)="finalizeStep(1)">Go to second step</button>
-        <button type="button" [goToStep]="{stepOffset: 2}" (preFinalize)="finalizeStep(1)">Go to third step</button>
-      </wizard-step>
-      <wizard-step stepTitle='Steptitle 2' optionalStep>
+        <button type="button" awGoToStep="0" (preFinalize)="finalizeStep(1)">Stay at this step</button>
+        <button type="button" [awGoToStep]="goToSecondStep" (preFinalize)="finalizeStep(1)">Go to second step</button>
+        <button type="button" [awGoToStep]="{stepOffset: 2}" (preFinalize)="finalizeStep(1)">Go to third step</button>
+      </aw-wizard-step>
+      <aw-wizard-step stepTitle='Steptitle 2' awOptionalStep>
         Step 2
-        <button type="button" [goToStep]="'2'" (finalize)="finalizeStep(2)">Go to third step</button>
-        <button type="button" [goToStep]="{incorrectKey: 3}" (finalize)="finalizeStep(2)">Invalid Button</button>
-      </wizard-step>
-      <wizard-step stepTitle='Steptitle 3'>
+        <button type="button" [awGoToStep]="'2'" (finalize)="finalizeStep(2)">Go to third step</button>
+        <button type="button" [awGoToStep]="{incorrectKey: 3}" (finalize)="finalizeStep(2)">Invalid Button</button>
+      </aw-wizard-step>
+      <aw-wizard-step stepTitle='Steptitle 3'>
         Step 3
-        <button type="button" [goToStep]="{stepOffset: -2}" (postFinalize)="finalizeStep(3)">Go to first step</button>
-      </wizard-step>
-    </wizard>
+        <button type="button" [awGoToStep]="{stepOffset: -2}" (postFinalize)="finalizeStep(3)">Go to first step</button>
+      </aw-wizard-step>
+    </aw-wizard>
   `
 })
 class WizardTestComponent {
@@ -62,18 +62,18 @@ describe('GoToStepDirective', () => {
     wizardTestFixture.detectChanges();
 
     wizardTest = wizardTestFixture.componentInstance;
-    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    wizardState = wizardTestFixture.debugElement.query(By.css('aw-wizard')).injector.get(WizardState);
     navigationMode = wizardState.navigationMode;
   });
 
   it('should create an instance', () => {
-    expect(wizardTestFixture.debugElement.query(By.css('wizard-navigation-bar'))
+    expect(wizardTestFixture.debugElement.query(By.css('aw-wizard-navigation-bar'))
       .queryAll(By.directive(GoToStepDirective)).length).toBe(3);
-    expect(wizardTestFixture.debugElement.query(By.css('wizard-step[stepTitle="Steptitle 1"]'))
+    expect(wizardTestFixture.debugElement.query(By.css('aw-wizard-step[stepTitle="Steptitle 1"]'))
       .queryAll(By.directive(GoToStepDirective)).length).toBe(3);
-    expect(wizardTestFixture.debugElement.query(By.css('wizard-step[stepTitle="Steptitle 2"]'))
+    expect(wizardTestFixture.debugElement.query(By.css('aw-wizard-step[stepTitle="Steptitle 2"]'))
       .queryAll(By.directive(GoToStepDirective)).length).toBe(2);
-    expect(wizardTestFixture.debugElement.query(By.css('wizard-step[stepTitle="Steptitle 3"]'))
+    expect(wizardTestFixture.debugElement.query(By.css('aw-wizard-step[stepTitle="Steptitle 3"]'))
       .queryAll(By.directive(GoToStepDirective)).length).toBe(1);
 
     expect(wizardTestFixture.debugElement.queryAll(By.directive(GoToStepDirective)).length).toBe(9);
@@ -81,9 +81,9 @@ describe('GoToStepDirective', () => {
 
   it('should move to step correctly', fakeAsync(() => {
     const firstStepGoToButton = wizardTestFixture.debugElement.query(
-      By.css('wizard-step[stepTitle="Steptitle 1"] > button:nth-child(2)')).nativeElement;
+      By.css('aw-wizard-step[stepTitle="Steptitle 1"] > button:nth-child(2)')).nativeElement;
     const secondStepGoToButton = wizardTestFixture.debugElement.query(
-      By.css('wizard-step[stepTitle="Steptitle 2"] > button')).nativeElement;
+      By.css('aw-wizard-step[stepTitle="Steptitle 2"] > button')).nativeElement;
 
     const wizardSteps = wizardState.wizardSteps;
 
@@ -115,9 +115,9 @@ describe('GoToStepDirective', () => {
 
   it('should jump over an optional step correctly', fakeAsync(() => {
     const firstStepGoToButton = wizardTestFixture.debugElement.query(
-      By.css('wizard-step[stepTitle="Steptitle 1"] > button:nth-child(3)')).nativeElement;
+      By.css('aw-wizard-step[stepTitle="Steptitle 1"] > button:nth-child(3)')).nativeElement;
     const thirdStepGoToButton = wizardTestFixture.debugElement.query(
-      By.css('wizard-step[stepTitle="Steptitle 3"] > button')).nativeElement;
+      By.css('aw-wizard-step[stepTitle="Steptitle 3"] > button')).nativeElement;
 
     const wizardSteps = wizardState.wizardSteps;
 
@@ -149,7 +149,7 @@ describe('GoToStepDirective', () => {
 
   it('should stay at current step correctly', fakeAsync(() => {
     const firstStepGoToButton = wizardTestFixture.debugElement.query(
-      By.css('wizard-step[stepTitle="Steptitle 1"] > button:nth-child(1)')).nativeElement;
+      By.css('aw-wizard-step[stepTitle="Steptitle 1"] > button:nth-child(1)')).nativeElement;
 
     const wizardSteps = wizardState.wizardSteps;
 
@@ -171,9 +171,9 @@ describe('GoToStepDirective', () => {
 
   it('should finalize step correctly', fakeAsync(() => {
     const firstStepGoToButton = wizardTestFixture.debugElement.query(
-      By.css('wizard-step[stepTitle="Steptitle 1"] > button:nth-child(3)')).nativeElement;
+      By.css('aw-wizard-step[stepTitle="Steptitle 1"] > button:nth-child(3)')).nativeElement;
     const thirdStepGoToButton = wizardTestFixture.debugElement.query(
-      By.css('wizard-step[stepTitle="Steptitle 3"] > button')).nativeElement;
+      By.css('aw-wizard-step[stepTitle="Steptitle 3"] > button')).nativeElement;
 
     expect(wizardState.currentStepIndex).toBe(0);
     expect(wizardTest.eventLog).toEqual([]);
@@ -195,30 +195,30 @@ describe('GoToStepDirective', () => {
     expect(wizardTest.eventLog).toEqual(['finalize 1', 'finalize 3']);
   }));
 
-  it('should throw an error when using an invalid goToStep value', fakeAsync(() => {
+  it('should throw an error when using an invalid destinationStep value', fakeAsync(() => {
     const invalidGoToAttribute = wizardTestFixture.debugElement
-      .query(By.css('wizard-step[stepTitle="Steptitle 2"]'))
+      .query(By.css('aw-wizard-step[stepTitle="Steptitle 2"]'))
       .queryAll(By.directive(GoToStepDirective))[1].injector.get(GoToStepDirective) as GoToStepDirective;
 
     expect(() => invalidGoToAttribute.destinationStep)
       .toThrow(new Error(`Input 'goToStep' is neither a WizardStep, StepOffset, number or string`));
   }));
 
-  it('should return correct destination step for correct goToStep values', fakeAsync(() => {
+  it('should return correct destination step for correct destinationStep values', fakeAsync(() => {
     const firstGoToAttribute = wizardTestFixture.debugElement
-      .query(By.css('wizard-navigation-bar'))
+      .query(By.css('aw-wizard-navigation-bar'))
       .queryAll(By.directive(GoToStepDirective))[0].injector.get(GoToStepDirective) as GoToStepDirective;
 
     const secondGoToAttribute = wizardTestFixture.debugElement
-      .query(By.css('wizard-step[stepTitle="Steptitle 1"]'))
+      .query(By.css('aw-wizard-step[stepTitle="Steptitle 1"]'))
       .queryAll(By.directive(GoToStepDirective))[1].injector.get(GoToStepDirective) as GoToStepDirective;
 
     const thirdGoToAttribute = wizardTestFixture.debugElement
-      .query(By.css('wizard-step[stepTitle="Steptitle 2"]'))
+      .query(By.css('aw-wizard-step[stepTitle="Steptitle 2"]'))
       .queryAll(By.directive(GoToStepDirective))[0].injector.get(GoToStepDirective) as GoToStepDirective;
 
     const fourthGoToAttribute = wizardTestFixture.debugElement
-      .query(By.css('wizard-step[stepTitle="Steptitle 3"]'))
+      .query(By.css('aw-wizard-step[stepTitle="Steptitle 3"]'))
       .queryAll(By.directive(GoToStepDirective))[0].injector.get(GoToStepDirective) as GoToStepDirective;
 
     expect(firstGoToAttribute.destinationStep).toBe(0);
@@ -234,7 +234,7 @@ describe('GoToStepDirective', () => {
     wizardTestFixture.detectChanges();
 
     const secondGoToAttribute = wizardTestFixture.debugElement
-      .query(By.css('wizard-navigation-bar'))
+      .query(By.css('aw-wizard-navigation-bar'))
       .queryAll(By.directive(GoToStepDirective))[1].nativeElement;
 
     secondGoToAttribute.click();

--- a/src/directives/go-to-step.directive.ts
+++ b/src/directives/go-to-step.directive.ts
@@ -10,7 +10,7 @@ import {WizardState} from '../navigation/wizard-state.model';
 import {NavigationMode} from '../navigation/navigation-mode.interface';
 
 /**
- * The `goToStep` directive can be used to navigate to a given step.
+ * The `awGoToStep` directive can be used to navigate to a given step.
  * This step can be defined in one of multiple formats
  *
  * ### Syntax
@@ -18,25 +18,25 @@ import {NavigationMode} from '../navigation/navigation-mode.interface';
  * With absolute step index:
  *
  * ```html
- * <button [goToStep]="absolute step index" (finalize)="finalize method">...</button>
+ * <button [awGoToStep]="absolute step index" (finalize)="finalize method">...</button>
  * ```
  *
  * With a wizard step object:
  *
  * ```html
- * <button [goToStep]="wizard step object" (finalize)="finalize method">...</button>
+ * <button [awGoToStep]="wizard step object" (finalize)="finalize method">...</button>
  * ```
  *
  * With an offset to the defining step
  *
  * ```html
- * <button [goToStep]="{ stepOffset: offset }" (finalize)="finalize method">...</button>
+ * <button [awGoToStep]="{ stepOffset: offset }" (finalize)="finalize method">...</button>
  * ```
  *
  * @author Marc Arndt
  */
 @Directive({
-  selector: '[goToStep]'
+  selector: '[awGoToStep]'
 })
 export class GoToStepDirective {
   /**
@@ -75,8 +75,9 @@ export class GoToStepDirective {
    * a [[StepOffset]] between the current step and the `wizardStep`, in which this directive has been used,
    * or a step index as a number or string
    */
-  @Input()
-  public goToStep: WizardStep | StepOffset | number | string;
+  // tslint:disable-next-line:no-input-rename
+  @Input('awGoToStep')
+  public targetStep: WizardStep | StepOffset | number | string;
 
   /**
    * The navigation mode
@@ -97,19 +98,19 @@ export class GoToStepDirective {
    * Returns the destination step of this directive as an absolute step index inside the wizard
    *
    * @returns The index of the destination step
-   * @throws If `goToStep` is of an unknown type an `Error` is thrown
+   * @throws If `targetStep` is of an unknown type an `Error` is thrown
    */
   get destinationStep(): number {
     let destinationStep: number;
 
-    if (isNumber(this.goToStep)) {
-      destinationStep = this.goToStep as number;
-    } else if (isString(this.goToStep)) {
-      destinationStep = parseInt(this.goToStep as string, 10);
-    } else if (isStepOffset(this.goToStep) && this.wizardStep !== null) {
-      destinationStep = this.wizardState.getIndexOfStep(this.wizardStep) + this.goToStep.stepOffset;
-    } else if (this.goToStep instanceof WizardStep) {
-      destinationStep = this.wizardState.getIndexOfStep(this.goToStep);
+    if (isNumber(this.targetStep)) {
+      destinationStep = this.targetStep as number;
+    } else if (isString(this.targetStep)) {
+      destinationStep = parseInt(this.targetStep as string, 10);
+    } else if (isStepOffset(this.targetStep) && this.wizardStep !== null) {
+      destinationStep = this.wizardState.getIndexOfStep(this.wizardStep) + this.targetStep.stepOffset;
+    } else if (this.targetStep instanceof WizardStep) {
+      destinationStep = this.wizardState.getIndexOfStep(this.targetStep);
     } else {
       throw new Error(`Input 'goToStep' is neither a WizardStep, StepOffset, number or string`);
     }

--- a/src/directives/go-to-step.directive.ts
+++ b/src/directives/go-to-step.directive.ts
@@ -112,7 +112,7 @@ export class GoToStepDirective {
     } else if (this.targetStep instanceof WizardStep) {
       destinationStep = this.wizardState.getIndexOfStep(this.targetStep);
     } else {
-      throw new Error(`Input 'goToStep' is neither a WizardStep, StepOffset, number or string`);
+      throw new Error(`Input 'targetStep' is neither a WizardStep, StepOffset, number or string`);
     }
 
     return destinationStep;

--- a/src/directives/next-step.directive.spec.ts
+++ b/src/directives/next-step.directive.spec.ts
@@ -7,19 +7,19 @@ import {WizardState} from '../navigation/wizard-state.model';
 import {NavigationMode} from '../navigation/navigation-mode.interface';
 
 @Component({
-  selector: 'test-wizard',
+  selector: 'aw-test-wizard',
   template: `
-    <wizard>
-      <wizard-step stepTitle='Steptitle 1'>
+    <aw-wizard>
+      <aw-wizard-step stepTitle='Steptitle 1'>
         Step 1
-        <button type="button" nextStep (finalize)="finalizeStep(1)">Go to second step</button>
-        <button type="button" nextStep (postFinalize)="finalizeStep(1)">Go to second step</button>
-      </wizard-step>
-      <wizard-step stepTitle='Steptitle 2'>
+        <button type="button" awNextStep (finalize)="finalizeStep(1)">Go to second step</button>
+        <button type="button" awNextStep (postFinalize)="finalizeStep(1)">Go to second step</button>
+      </aw-wizard-step>
+      <aw-wizard-step stepTitle='Steptitle 2'>
         Step 2
-        <button type="button" nextStep (postFinalize)="finalizeStep(2)">Go to first step</button>
-      </wizard-step>
-    </wizard>
+        <button type="button" awNextStep (postFinalize)="finalizeStep(2)">Go to first step</button>
+      </aw-wizard-step>
+    </aw-wizard>
   `
 })
 class WizardTestComponent {
@@ -49,24 +49,24 @@ describe('NextStepDirective', () => {
     wizardTestFixture.detectChanges();
 
     wizardTest = wizardTestFixture.componentInstance;
-    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    wizardState = wizardTestFixture.debugElement.query(By.css('aw-wizard')).injector.get(WizardState);
     navigationMode = wizardState.navigationMode;
   });
 
   it('should create an instance', () => {
     expect(wizardTestFixture.debugElement.query(
-      By.css('wizard-step[stepTitle="Steptitle 1"] > button[nextStep]'))).toBeTruthy();
+      By.css('aw-wizard-step[stepTitle="Steptitle 1"] > button[awNextStep]'))).toBeTruthy();
     expect(wizardTestFixture.debugElement.query(
-      By.css('wizard-step[stepTitle="Steptitle 2"] > button[nextStep]'))).toBeTruthy();
+      By.css('aw-wizard-step[stepTitle="Steptitle 2"] > button[awNextStep]'))).toBeTruthy();
     expect(wizardTestFixture.debugElement.queryAll(
       By.directive(NextStepDirective)).length).toBe(3);
   });
 
   it('should move correctly to the next step', fakeAsync(() => {
     const firstStepButton = wizardTestFixture.debugElement.query(
-      By.css('wizard-step[stepTitle="Steptitle 1"] > button[nextStep]')).nativeElement;
+      By.css('aw-wizard-step[stepTitle="Steptitle 1"] > button[awNextStep]')).nativeElement;
     const secondStepButton = wizardTestFixture.debugElement.query(
-      By.css('wizard-step[stepTitle="Steptitle 2"] > button[nextStep]')).nativeElement;
+      By.css('aw-wizard-step[stepTitle="Steptitle 2"] > button[awNextStep]')).nativeElement;
 
     expect(wizardState.currentStepIndex).toBe(0);
 
@@ -87,7 +87,7 @@ describe('NextStepDirective', () => {
 
   it('should call finalize correctly when going the next step', fakeAsync(() => {
     const firstStepButtons = wizardTestFixture.debugElement.queryAll(
-      By.css('wizard-step[stepTitle="Steptitle 1"] > button[nextStep]'));
+      By.css('aw-wizard-step[stepTitle="Steptitle 1"] > button[awNextStep]'));
 
     expect(wizardTest.eventLog).toEqual([]);
 
@@ -101,7 +101,7 @@ describe('NextStepDirective', () => {
 
   it('should call postFinalize correctly when going the next step', fakeAsync(() => {
     const firstStepButtons = wizardTestFixture.debugElement.queryAll(
-      By.css('wizard-step[stepTitle="Steptitle 1"] > button[nextStep]'));
+      By.css('aw-wizard-step[stepTitle="Steptitle 1"] > button[awNextStep]'));
 
     expect(wizardTest.eventLog).toEqual([]);
 
@@ -115,7 +115,7 @@ describe('NextStepDirective', () => {
 
   it('shouldn\'t call finalize when going to an nonexistent step', fakeAsync(() => {
     const secondStepButton = wizardTestFixture.debugElement.query(
-      By.css('wizard-step[stepTitle="Steptitle 2"] > button[nextStep]')).nativeElement;
+      By.css('aw-wizard-step[stepTitle="Steptitle 2"] > button[awNextStep]')).nativeElement;
 
     navigationMode.goToStep(1);
     tick();

--- a/src/directives/next-step.directive.ts
+++ b/src/directives/next-step.directive.ts
@@ -3,18 +3,18 @@ import {NavigationMode} from '../navigation/navigation-mode.interface';
 import {WizardState} from '../navigation/wizard-state.model';
 
 /**
- * The `nextStep` directive can be used to navigate to the next step.
+ * The `awNextStep` directive can be used to navigate to the next step.
  *
  * ### Syntax
  *
  * ```html
- * <button nextStep (finalize)="finalize method">...</button>
+ * <button awNextStep (finalize)="finalize method">...</button>
  * ```
  *
  * @author Marc Arndt
  */
 @Directive({
-  selector: '[nextStep]'
+  selector: '[awNextStep]'
 })
 export class NextStepDirective {
   /**

--- a/src/directives/optional-step.directive.spec.ts
+++ b/src/directives/optional-step.directive.spec.ts
@@ -7,19 +7,19 @@ import {WizardState} from '../navigation/wizard-state.model';
 import {NavigationMode} from '../navigation/navigation-mode.interface';
 
 @Component({
-  selector: 'test-wizard',
+  selector: 'aw-test-wizard',
   template: `
-    <wizard>
-      <wizard-step stepTitle='Steptitle 1'>
+    <aw-wizard>
+      <aw-wizard-step stepTitle='Steptitle 1'>
         Step 1
-      </wizard-step>
-      <wizard-step stepTitle='Steptitle 2' optionalStep>
+      </aw-wizard-step>
+      <aw-wizard-step stepTitle='Steptitle 2' awOptionalStep>
         Step 2
-      </wizard-step>
-      <wizard-step stepTitle='Steptitle 3'>
+      </aw-wizard-step>
+      <aw-wizard-step stepTitle='Steptitle 3'>
         Step 3
-      </wizard-step>
-    </wizard>
+      </aw-wizard-step>
+    </aw-wizard>
   `
 })
 class WizardTestComponent {
@@ -44,7 +44,7 @@ describe('OptionalStepDirective', () => {
     wizardTestFixture.detectChanges();
 
     wizardTest = wizardTestFixture.componentInstance;
-    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    wizardState = wizardTestFixture.debugElement.query(By.css('aw-wizard')).injector.get(WizardState);
     navigationMode = wizardState.navigationMode;
   });
 

--- a/src/directives/optional-step.directive.ts
+++ b/src/directives/optional-step.directive.ts
@@ -2,29 +2,29 @@ import {Directive, Host, OnInit} from '@angular/core';
 import {WizardStep} from '../util/wizard-step.interface';
 
 /**
- * The `optionalStep` directive can be used to define an optional `wizard-step`.
- * An optional `wizard-step` is a [[WizardStep]] that doesn't need to be completed to transition to later wizard steps.
+ * The `awOptionalStep` directive can be used to define an optional `wizard-step`.
+ * An optional wizard step is a [[WizardStep]] that doesn't need to be completed to transition to later wizard steps.
  *
  * ### Syntax
  *
  * ```html
- * <wizard-step optionalStep>
+ * <aw-wizard-step awOptionalStep>
  *     ...
- * </wizard-step>
+ * </aw-wizard-step>
  * ```
  *
  * ### Example
  *
  * ```html
- * <wizard-step stepTitle="Second step" optionalStep>
+ * <aw-wizard-step stepTitle="Second step" awOptionalStep>
  *     ...
- * </wizard-step>
+ * </aw-wizard-step>
  * ```
  *
  * @author Marc Arndt
  */
 @Directive({
-  selector: '[optionalStep]'
+  selector: '[awOptionalStep]'
 })
 export class OptionalStepDirective implements OnInit {
   /**

--- a/src/directives/previous-step.directive.spec.ts
+++ b/src/directives/previous-step.directive.spec.ts
@@ -7,19 +7,19 @@ import {WizardState} from '../navigation/wizard-state.model';
 import {NavigationMode} from '../navigation/navigation-mode.interface';
 
 @Component({
-  selector: 'test-wizard',
+  selector: 'aw-test-wizard',
   template: `
-    <wizard>
-      <wizard-step stepTitle='Steptitle 1'>
+    <aw-wizard>
+      <aw-wizard-step stepTitle='Steptitle 1'>
         Step 1
-        <button type="button" (finalize)="finalizeStep(1)" previousStep>Go to zero step</button>
-      </wizard-step>
-      <wizard-step stepTitle='Steptitle 2'>
+        <button type="button" (finalize)="finalizeStep(1)" awPreviousStep>Go to zero step</button>
+      </aw-wizard-step>
+      <aw-wizard-step stepTitle='Steptitle 2'>
         Step 2
-        <button type="button" (finalize)="finalizeStep(2)" previousStep>Go to first step</button>
-        <button type="button" (postFinalize)="finalizeStep(2)" previousStep>Go to first step</button>
-      </wizard-step>
-    </wizard>
+        <button type="button" (finalize)="finalizeStep(2)" awPreviousStep>Go to first step</button>
+        <button type="button" (postFinalize)="finalizeStep(2)" awPreviousStep>Go to first step</button>
+      </aw-wizard-step>
+    </aw-wizard>
   `
 })
 class WizardTestComponent {
@@ -49,24 +49,24 @@ describe('PreviousStepDirective', () => {
     wizardTestFixture.detectChanges();
 
     wizardTest = wizardTestFixture.componentInstance;
-    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    wizardState = wizardTestFixture.debugElement.query(By.css('aw-wizard')).injector.get(WizardState);
     navigationMode = wizardState.navigationMode;
   });
 
   it('should create an instance', () => {
     expect(wizardTestFixture.debugElement.query(
-      By.css('wizard-step[stepTitle="Steptitle 1"] > button[previousStep]'))).toBeTruthy();
+      By.css('aw-wizard-step[stepTitle="Steptitle 1"] > button[awPreviousStep]'))).toBeTruthy();
     expect(wizardTestFixture.debugElement.query(
-      By.css('wizard-step[stepTitle="Steptitle 2"] > button[previousStep]'))).toBeTruthy();
+      By.css('aw-wizard-step[stepTitle="Steptitle 2"] > button[awPreviousStep]'))).toBeTruthy();
     expect(wizardTestFixture.debugElement.queryAll(
       By.directive(PreviousStepDirective)).length).toBe(3);
   });
 
   it('should move correctly to the previous step', fakeAsync(() => {
     const firstStepButton = wizardTestFixture.debugElement.query(
-      By.css('wizard-step[stepTitle="Steptitle 1"] > button[previousStep]')).nativeElement;
+      By.css('aw-wizard-step[stepTitle="Steptitle 1"] > button[awPreviousStep]')).nativeElement;
     const secondStepButton = wizardTestFixture.debugElement.query(
-      By.css('wizard-step[stepTitle="Steptitle 2"] > button[previousStep]')).nativeElement;
+      By.css('aw-wizard-step[stepTitle="Steptitle 2"] > button[awPreviousStep]')).nativeElement;
 
     expect(wizardState.currentStepIndex).toBe(0);
 
@@ -77,7 +77,7 @@ describe('PreviousStepDirective', () => {
 
     expect(wizardState.currentStepIndex).toBe(0);
 
-    // move to second step to test the previousStep directive
+    // move to second step to test the awPreviousStep directive
     navigationMode.goToStep(1);
     tick();
     wizardTestFixture.detectChanges();
@@ -94,7 +94,7 @@ describe('PreviousStepDirective', () => {
 
   it('should call finalize correctly when going the previous step', fakeAsync(() => {
     const secondStepButtons = wizardTestFixture.debugElement.queryAll(
-      By.css('wizard-step[stepTitle="Steptitle 2"] > button[previousStep]'));
+      By.css('aw-wizard-step[stepTitle="Steptitle 2"] > button[awPreviousStep]'));
 
     navigationMode.goToStep(1);
     tick();
@@ -112,7 +112,7 @@ describe('PreviousStepDirective', () => {
 
   it('should call postFinalize correctly when going the previous step', fakeAsync(() => {
     const secondStepButtons = wizardTestFixture.debugElement.queryAll(
-      By.css('wizard-step[stepTitle="Steptitle 2"] > button[previousStep]'));
+      By.css('aw-wizard-step[stepTitle="Steptitle 2"] > button[awPreviousStep]'));
 
     navigationMode.goToStep(1);
     tick();
@@ -130,7 +130,7 @@ describe('PreviousStepDirective', () => {
 
   it('shouldn\'t call finalize when going to an nonexistent step', fakeAsync(() => {
     const firstStepButton = wizardTestFixture.debugElement.query(
-      By.css('wizard-step[stepTitle="Steptitle 1"] > button[previousStep]')).nativeElement;
+      By.css('aw-wizard-step[stepTitle="Steptitle 1"] > button[awPreviousStep]')).nativeElement;
 
     expect(wizardTest.eventLog).toEqual([]);
 

--- a/src/directives/previous-step.directive.ts
+++ b/src/directives/previous-step.directive.ts
@@ -3,19 +3,19 @@ import {NavigationMode} from '../navigation/navigation-mode.interface';
 import {WizardState} from '../navigation/wizard-state.model';
 
 /**
- * The `previousStep` directive can be used to navigate to the previous step.
+ * The `awPreviousStep` directive can be used to navigate to the previous step.
  * Compared to the [[NextStepDirective]] it's important to note, that this directive doesn't contain a `finalize` output method.
  *
  * ### Syntax
  *
  * ```html
- * <button previousStep>...</button>
+ * <button awPreviousStep>...</button>
  * ```
  *
  * @author Marc Arndt
  */
 @Directive({
-  selector: '[previousStep]'
+  selector: '[awPreviousStep]'
 })
 export class PreviousStepDirective {
   /**

--- a/src/directives/reset-wizard.directive.spec.ts
+++ b/src/directives/reset-wizard.directive.spec.ts
@@ -8,18 +8,18 @@ import {NavigationMode} from '../navigation/navigation-mode.interface';
 import {ResetWizardDirective} from './reset-wizard.directive';
 
 @Component({
-  selector: 'test-wizard',
+  selector: 'aw-test-wizard',
   template: `
-    <wizard>
-      <wizard-step stepTitle='Steptitle 1'>
+    <aw-wizard>
+      <aw-wizard-step stepTitle='Steptitle 1'>
         Step 1
-      </wizard-step>
-      <wizard-step stepTitle='Steptitle 2'>
+      </aw-wizard-step>
+      <aw-wizard-step stepTitle='Steptitle 2'>
         Step 2
-        <button type="button" resetWizard>Reset (normal)</button>
-        <button type="button" resetWizard (finalize)='cleanup()'>Reset (cleanup)</button>
-      </wizard-step>
-    </wizard>
+        <button type="button" awResetWizard>Reset (normal)</button>
+        <button type="button" awResetWizard (finalize)='cleanup()'>Reset (cleanup)</button>
+      </aw-wizard-step>
+    </aw-wizard>
   `
 })
 class WizardTestComponent {
@@ -49,7 +49,7 @@ describe('ResetWizardDirective', () => {
     wizardTestFixture.detectChanges();
 
     wizardTest = wizardTestFixture.componentInstance;
-    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    wizardState = wizardTestFixture.debugElement.query(By.css('aw-wizard')).injector.get(WizardState);
     navigationMode = wizardState.navigationMode;
   });
 

--- a/src/directives/reset-wizard.directive.ts
+++ b/src/directives/reset-wizard.directive.ts
@@ -3,19 +3,19 @@ import {WizardState} from '../navigation/wizard-state.model';
 import {NavigationMode} from '../navigation/navigation-mode.interface';
 
 /**
- * The `resetWizard` directive can be used to reset the wizard to its initial state.
+ * The `awResetWizard` directive can be used to reset the wizard to its initial state.
  * This directive accepts an output, which can be used to specify some custom cleanup work during the reset process.
  *
  * ### Syntax
  *
  * ```html
- * <button resetWizard (finalize)="custom reset task">...</button>
+ * <button awResetWizard (finalize)="custom reset task">...</button>
  * ```
  *
  * @author Marc Arndt
  */
 @Directive({
-  selector: '[resetWizard]'
+  selector: '[awResetWizard]'
 })
 export class ResetWizardDirective {
   /**

--- a/src/directives/selected-step.directive.spec.ts
+++ b/src/directives/selected-step.directive.spec.ts
@@ -7,19 +7,19 @@ import {NavigationMode} from '../navigation/navigation-mode.interface';
 import {SelectedStepDirective} from './selected-step.directive';
 
 @Component({
-  selector: 'test-wizard',
+  selector: 'aw-test-wizard',
   template: `
-    <wizard navigationMode="free">
-      <wizard-step stepTitle='Steptitle 1'>
+    <aw-wizard navigationMode="free">
+      <aw-wizard-step stepTitle='Steptitle 1'>
         Step 1
-      </wizard-step>
-      <wizard-step stepTitle='Steptitle 2' selectedStep>
+      </aw-wizard-step>
+      <aw-wizard-step stepTitle='Steptitle 2' awSelectedStep>
         Step 2
-      </wizard-step>
-      <wizard-step stepTitle='Steptitle 3'>
+      </aw-wizard-step>
+      <aw-wizard-step stepTitle='Steptitle 3'>
         Step 3
-      </wizard-step>
-    </wizard>
+      </aw-wizard-step>
+    </aw-wizard>
   `
 })
 class WizardTestComponent {
@@ -44,7 +44,7 @@ describe('SelectedStepDirective', () => {
     wizardTestFixture.detectChanges();
 
     wizardTest = wizardTestFixture.componentInstance;
-    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    wizardState = wizardTestFixture.debugElement.query(By.css('aw-wizard')).injector.get(WizardState);
     navigationMode = wizardState.navigationMode;
   });
 

--- a/src/directives/selected-step.directive.ts
+++ b/src/directives/selected-step.directive.ts
@@ -2,20 +2,20 @@ import {Directive, Host, OnInit} from '@angular/core';
 import {WizardStep} from '../util/wizard-step.interface';
 
 /**
- * The `selectedStep` directive can be used on a [[WizardStep]] to set it as selected after the wizard initialisation or a reset.
+ * The `awSelectedStep` directive can be used on a [[WizardStep]] to set it as selected after the wizard initialisation or a reset.
  *
  * ### Syntax
  *
  * ```html
- * <wizard-step stepTitle="Step title" selected>
+ * <aw-wizard-step stepTitle="Step title" awSelectedStep>
  *     ...
- * </wizard-step>
+ * </aw-wizard-step>
  * ```
  *
  * @author Marc Arndt
  */
 @Directive({
-  selector: '[selectedStep]'
+  selector: '[awSelectedStep]'
 })
 export class SelectedStepDirective implements OnInit {
   /**

--- a/src/directives/wizard-completion-step.directive.spec.ts
+++ b/src/directives/wizard-completion-step.directive.spec.ts
@@ -11,20 +11,20 @@ import {NavigationMode} from '../navigation/navigation-mode.interface';
 import {WizardState} from '../navigation/wizard-state.model';
 
 @Component({
-  selector: 'test-wizard',
+  selector: 'aw-test-wizard',
   template: `
-    <wizard>
-      <wizard-step stepTitle='Steptitle 1' (stepEnter)="enterInto($event, 1)" (stepExit)="exitFrom($event, 1)">
+    <aw-wizard>
+      <aw-wizard-step stepTitle='Steptitle 1' (stepEnter)="enterInto($event, 1)" (stepExit)="exitFrom($event, 1)">
         Step 1
-      </wizard-step>
-      <wizard-step stepTitle='Steptitle 2' [canExit]="isValid"
-                   optionalStep (stepEnter)="enterInto($event, 2)" (stepExit)="exitFrom($event, 2)">
+      </aw-wizard-step>
+      <aw-wizard-step stepTitle='Steptitle 2' [canExit]="isValid"
+                   awOptionalStep (stepEnter)="enterInto($event, 2)" (stepExit)="exitFrom($event, 2)">
         Step 2
-      </wizard-step>
-      <div wizardCompletionStep stepTitle='Completion steptitle 3' (stepEnter)="enterInto($event, 3)">
+      </aw-wizard-step>
+      <div awWizardCompletionStep stepTitle='Completion steptitle 3' (stepEnter)="enterInto($event, 3)">
         Step 3
       </div>
-    </wizard>
+    </aw-wizard>
   `
 })
 class WizardTestComponent {
@@ -60,13 +60,13 @@ describe('WizardCompletionStepDirective', () => {
     wizardTestFixture.detectChanges();
 
     wizardTest = wizardTestFixture.componentInstance;
-    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    wizardState = wizardTestFixture.debugElement.query(By.css('aw-wizard')).injector.get(WizardState);
     navigationMode = wizardState.navigationMode;
   });
 
   it('should create', () => {
     expect(wizardTest).toBeTruthy();
-    expect(wizardTestFixture.debugElement.queryAll(By.css('wizard-step')).length).toBe(2);
+    expect(wizardTestFixture.debugElement.queryAll(By.css('aw-wizard-step')).length).toBe(2);
     expect(wizardTestFixture.debugElement.queryAll(By.directive(WizardCompletionStepDirective)).length).toBe(1);
   });
 });

--- a/src/directives/wizard-completion-step.directive.ts
+++ b/src/directives/wizard-completion-step.directive.ts
@@ -3,7 +3,7 @@ import {WizardStep} from '../util/wizard-step.interface';
 import {WizardCompletionStep} from '../util/wizard-completion-step.interface';
 
 /**
- * The `wizardCompletionStep` directive can be used to define a completion/success step at the end of your wizard
+ * The `awWizardCompletionStep` directive can be used to define a completion/success step at the end of your wizard
  * After a [[WizardCompletionStep]] has been entered, it has the characteristic that the user is blocked from
  * leaving it again to a previous step.
  * In addition entering a [[WizardCompletionStep]] automatically sets the `wizard` amd all steps inside the `wizard`
@@ -12,7 +12,7 @@ import {WizardCompletionStep} from '../util/wizard-completion-step.interface';
  * ### Syntax
  *
  * ```html
- * <div wizardCompletionStep [stepTitle]="title of the wizard step" [navigationSymbol]="navigation symbol"
+ * <div awWizardCompletionStep [stepTitle]="title of the wizard step" [navigationSymbol]="navigation symbol"
  *    [navigationSymbolFontFamily]="navigation symbol font family"
  *    (stepEnter)="event emitter to be called when the wizard step is entered"
  *    (stepExit)="event emitter to be called when the wizard step is exited">
@@ -23,7 +23,7 @@ import {WizardCompletionStep} from '../util/wizard-completion-step.interface';
  * ### Example
  *
  * ```html
- * <div wizardCompletionStep stepTitle="Step 1" navigationSymbol="1">
+ * <div awWizardCompletionStep stepTitle="Step 1" navigationSymbol="1">
  *    ...
  * </div>
  * ```
@@ -31,7 +31,7 @@ import {WizardCompletionStep} from '../util/wizard-completion-step.interface';
  * With a navigation symbol from the `font-awesome` font:
  *
  * ```html
- * <div wizardCompletionStep stepTitle="Step 1" navigationSymbol="&#xf1ba;" navigationSymbolFontFamily="FontAwesome">
+ * <div awWizardCompletionStep stepTitle="Step 1" navigationSymbol="&#xf1ba;" navigationSymbolFontFamily="FontAwesome">
  *    ...
  * </div>
  * ```
@@ -39,7 +39,7 @@ import {WizardCompletionStep} from '../util/wizard-completion-step.interface';
  * @author Marc Arndt
  */
 @Directive({
-  selector: '[wizardCompletionStep]',
+  selector: '[awWizardCompletionStep]',
   providers: [
     { provide: WizardStep, useExisting: forwardRef(() => WizardCompletionStepDirective) },
     { provide: WizardCompletionStep, useExisting: forwardRef(() => WizardCompletionStepDirective) }

--- a/src/directives/wizard-step-title.directive.spec.ts
+++ b/src/directives/wizard-step-title.directive.spec.ts
@@ -10,22 +10,22 @@ import {ArchwizardModule} from '../archwizard.module';
 
 
 @Component({
-  selector: 'test-wizard',
+  selector: 'aw-test-wizard',
   template: `
-    <wizard>
-      <wizard-step stepTitle='Not visible title'>
-        <ng-template stepTitle>
+    <aw-wizard>
+      <aw-wizard-step stepTitle='Not visible title'>
+        <ng-template awStepTitle>
           Steptitle 1
         </ng-template>
         Step 1
-      </wizard-step>
-      <wizard-completion-step stepTitle='Other not visible title'>
-        <ng-template wizardStepTitle>
+      </aw-wizard-step>
+      <aw-wizard-completion-step stepTitle='Other not visible title'>
+        <ng-template awWizardStepTitle>
           Steptitle 2
         </ng-template>
         Step 2
-      </wizard-completion-step>
-    </wizard>
+      </aw-wizard-completion-step>
+    </aw-wizard>
   `
 })
 class WizardTestComponent {
@@ -33,7 +33,7 @@ class WizardTestComponent {
   public wizard: WizardComponent;
 }
 
-describe('PreviousStepDirective', () => {
+describe('WizardStepTitleDirective', () => {
   let wizardTest: WizardTestComponent;
   let wizardTestFixture: ComponentFixture<WizardTestComponent>;
 
@@ -52,7 +52,7 @@ describe('PreviousStepDirective', () => {
   });
 
   it('should create an instance', () => {
-    let navigationLinks = wizardTestFixture.debugElement.queryAll(By.css('wizard-navigation-bar ul li a'));
+    let navigationLinks = wizardTestFixture.debugElement.queryAll(By.css('aw-wizard-navigation-bar ul li a'));
 
     expect(navigationLinks.length).toBe(2);
     expect(navigationLinks[0].nativeElement.innerText).toBe('STEPTITLE 1');

--- a/src/directives/wizard-step-title.directive.ts
+++ b/src/directives/wizard-step-title.directive.ts
@@ -4,14 +4,14 @@
 import {Directive, TemplateRef} from '@angular/core';
 
 /**
- * The `wizardStepTitle` directive can be used as an alternative to the `stepTitle` input of a [[WizardStep]]
+ * The `awWizardStepTitle` directive can be used as an alternative to the `stepTitle` input of a [[WizardStep]]
  * to define the content of a step title inside the navigation bar.
  * This step title can be freely created and can contain more than only plain text
  *
  * ### Syntax
  *
  * ```html
- * <ng-template wizardStepTitle>
+ * <ng-template awWizardStepTitle>
  *     ...
  * </ng-template>
  * ```
@@ -19,7 +19,7 @@ import {Directive, TemplateRef} from '@angular/core';
  * @author Marc Arndt
  */
 @Directive({
-  selector: 'ng-template[stepTitle], ng-template[wizardStepTitle]'
+  selector: 'ng-template[awStepTitle], ng-template[awWizardStepTitle]'
 })
 export class WizardStepTitleDirective {
   /**

--- a/src/directives/wizard-step.directive.spec.ts
+++ b/src/directives/wizard-step.directive.spec.ts
@@ -8,19 +8,19 @@ import {WizardState} from '../navigation/wizard-state.model';
 import {NavigationMode} from '../navigation/navigation-mode.interface';
 
 @Component({
-  selector: 'test-wizard',
+  selector: 'aw-test-wizard',
   template: `
-    <wizard>
-      <div wizardStep stepTitle='Steptitle 1' (stepEnter)="enterInto($event, 1)" (stepExit)="exitFrom($event, 1)">
+    <aw-wizard>
+      <div awWizardStep stepTitle='Steptitle 1' (stepEnter)="enterInto($event, 1)" (stepExit)="exitFrom($event, 1)">
         Step 1
       </div>
-      <test-wizard-step wizardStep stepTitle='Steptitle 2' optionalStep>
+      <aw-test-wizard-step awWizardStep stepTitle='Steptitle 2' awOptionalStep>
         Step 2
-      </test-wizard-step>
-      <div wizardStep stepTitle='Steptitle 3' (stepEnter)="enterInto($event, 3)" (stepExit)="exitFrom($event, 3)">
+      </aw-test-wizard-step>
+      <div awWizardStep stepTitle='Steptitle 3' (stepEnter)="enterInto($event, 3)" (stepExit)="exitFrom($event, 3)">
         Step 3
       </div>
-    </wizard>
+    </aw-wizard>
   `
 })
 class WizardTestComponent {
@@ -39,7 +39,7 @@ class WizardTestComponent {
 }
 
 @Component({
-  selector: 'test-wizard-step',
+  selector: 'aw-test-wizard-step',
   template: `
     Step 2
   `
@@ -70,7 +70,7 @@ describe('WizardStepDirective', () => {
     wizardTestFixture.detectChanges();
 
     wizardTest = wizardTestFixture.componentInstance;
-    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    wizardState = wizardTestFixture.debugElement.query(By.css('aw-wizard')).injector.get(WizardState);
     navigationMode = wizardState.navigationMode;
   });
 

--- a/src/directives/wizard-step.directive.ts
+++ b/src/directives/wizard-step.directive.ts
@@ -2,25 +2,25 @@ import {Directive, forwardRef} from '@angular/core';
 import {WizardStep} from '../util/wizard-step.interface';
 
 /**
- * The `wizardStep` directive can be used to define a normal step inside a wizard.
+ * The `awWizardStep` directive can be used to define a normal step inside a wizard.
  *
  * ### Syntax
  *
  * With `stepTitle` input:
  *
  * ```html
- * <div wizardStep [stepTitle]="step title" [navigationSymbol]="symbol" [navigationSymbolFontFamily]="font-family"
+ * <div awWizardStep [stepTitle]="step title" [navigationSymbol]="symbol" [navigationSymbolFontFamily]="font-family"
  *    [canExit]="deciding function" (stepEnter)="enter function" (stepExit)="exit function">
  *    ...
  * </div>
  * ```
  *
- * With `wizardStepTitle` directive:
+ * With `awWizardStepTitle` directive:
  *
  * ```html
- * <div wizardStep [navigationSymbol]="symbol" [navigationSymbolFontFamily]="font-family"
+ * <div awWizardStep [navigationSymbol]="symbol" [navigationSymbolFontFamily]="font-family"
  *    [canExit]="deciding function" (stepEnter)="enter function" (stepExit)="exit function">
- *    <ng-template wizardStepTitle>
+ *    <ng-template awWizardStepTitle>
  *        step title
  *    </ng-template>
  *    ...
@@ -32,16 +32,16 @@ import {WizardStep} from '../util/wizard-step.interface';
  * With `stepTitle` input:
  *
  * ```html
- * <div wizardStep stepTitle="Address information" navigationSymbol="&#xf1ba;" navigationSymbolFontFamily="FontAwesome">
+ * <div awWizardStep stepTitle="Address information" navigationSymbol="&#xf1ba;" navigationSymbolFontFamily="FontAwesome">
  *    ...
  * </div>
  * ```
  *
- * With `wizardStepTitle` directive:
+ * With `awWizardStepTitle` directive:
  *
  * ```html
- * <div wizardStep navigationSymbol="&#xf1ba;" navigationSymbolFontFamily="FontAwesome">
- *    <ng-template wizardStepTitle>
+ * <div awWizardStep navigationSymbol="&#xf1ba;" navigationSymbolFontFamily="FontAwesome">
+ *    <ng-template awWizardStepTitle>
  *        Address information
  *    </ng-template>
  * </div>
@@ -50,7 +50,7 @@ import {WizardStep} from '../util/wizard-step.interface';
  * @author Marc Arndt
  */
 @Directive({
-  selector: '[wizardStep]',
+  selector: '[awWizardStep]',
   providers: [
     { provide: WizardStep, useExisting: forwardRef(() => WizardStepDirective) }
   ]

--- a/src/navigation/free-navigation-mode.spec.ts
+++ b/src/navigation/free-navigation-mode.spec.ts
@@ -8,13 +8,13 @@ import {NavigationMode} from './navigation-mode.interface';
 import {FreeNavigationMode} from './free-navigation-mode';
 
 @Component({
-  selector: 'test-wizard',
+  selector: 'aw-test-wizard',
   template: `
-    <wizard navigationMode="free">
-      <wizard-step stepTitle='Steptitle 1'>Step 1</wizard-step>
-      <wizard-step stepTitle='Steptitle 2'>Step 2</wizard-step>
-      <wizard-step stepTitle='Steptitle 3'>Step 3</wizard-step>
-    </wizard>
+    <aw-wizard navigationMode="free">
+      <aw-wizard-step stepTitle='Steptitle 1'>Step 1</aw-wizard-step>
+      <aw-wizard-step stepTitle='Steptitle 2'>Step 2</aw-wizard-step>
+      <aw-wizard-step stepTitle='Steptitle 3'>Step 3</aw-wizard-step>
+    </aw-wizard>
   `
 })
 class WizardTestComponent {
@@ -41,13 +41,13 @@ describe('FreeNavigationMode', () => {
     wizardTestFixture.detectChanges();
 
     wizardTest = wizardTestFixture.componentInstance;
-    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    wizardState = wizardTestFixture.debugElement.query(By.css('aw-wizard')).injector.get(WizardState);
     navigationMode = wizardState.navigationMode;
   });
 
   it('should create', () => {
     expect(wizardTest).toBeTruthy();
-    expect(wizardTestFixture.debugElement.query(By.css('wizard'))).toBeTruthy();
+    expect(wizardTestFixture.debugElement.query(By.css('aw-wizard'))).toBeTruthy();
     expect(navigationMode instanceof FreeNavigationMode).toBe(true,
       'Navigation mode is not an instance of FreeNavigationMode');
   });

--- a/src/navigation/semi-strict-navigation-mode.spec.ts
+++ b/src/navigation/semi-strict-navigation-mode.spec.ts
@@ -8,13 +8,13 @@ import {NavigationMode} from './navigation-mode.interface';
 import {SemiStrictNavigationMode} from './semi-strict-navigation-mode';
 
 @Component({
-  selector: 'test-wizard',
+  selector: 'aw-test-wizard',
   template: `
-    <wizard navigationMode="semi-strict">
-      <wizard-step stepTitle='Steptitle 1'>Step 1</wizard-step>
-      <wizard-step stepTitle='Steptitle 2'>Step 2</wizard-step>
-      <wizard-completion-step enableBackLinks stepTitle='Completion Steptitle'>Step 3</wizard-completion-step>
-    </wizard>
+    <aw-wizard navigationMode="semi-strict">
+      <aw-wizard-step stepTitle='Steptitle 1'>Step 1</aw-wizard-step>
+      <aw-wizard-step stepTitle='Steptitle 2'>Step 2</aw-wizard-step>
+      <aw-wizard-completion-step awEnableBackLinks stepTitle='Completion Steptitle'>Step 3</aw-wizard-completion-step>
+    </aw-wizard>
   `
 })
 class WizardTestComponent {
@@ -41,13 +41,13 @@ describe('SemiStrictNavigationMode', () => {
     wizardTestFixture.detectChanges();
 
     wizardTest = wizardTestFixture.componentInstance;
-    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    wizardState = wizardTestFixture.debugElement.query(By.css('aw-wizard')).injector.get(WizardState);
     navigationMode = wizardState.navigationMode;
   });
 
   it('should create', () => {
     expect(wizardTest).toBeTruthy();
-    expect(wizardTestFixture.debugElement.query(By.css('wizard'))).toBeTruthy();
+    expect(wizardTestFixture.debugElement.query(By.css('aw-wizard'))).toBeTruthy();
     expect(navigationMode instanceof SemiStrictNavigationMode).toBe(true,
       'Navigation mode is not an instance of SemiStrictNavigationMode');
   });

--- a/src/navigation/strict-navigation-mode.spec.ts
+++ b/src/navigation/strict-navigation-mode.spec.ts
@@ -9,13 +9,13 @@ import {NavigationMode} from './navigation-mode.interface';
 import {StrictNavigationMode} from './strict-navigation-mode';
 
 @Component({
-  selector: 'test-wizard',
+  selector: 'aw-test-wizard',
   template: `
-    <wizard>
-      <wizard-step stepTitle='Steptitle 1' optionalStep>Step 1</wizard-step>
-      <wizard-step stepTitle='Steptitle 2'>Step 2</wizard-step>
-      <wizard-step stepTitle='Steptitle 3'>Step 3</wizard-step>
-    </wizard>
+    <aw-wizard>
+      <aw-wizard-step stepTitle='Steptitle 1' awOptionalStep>Step 1</aw-wizard-step>
+      <aw-wizard-step stepTitle='Steptitle 2'>Step 2</aw-wizard-step>
+      <aw-wizard-step stepTitle='Steptitle 3'>Step 3</aw-wizard-step>
+    </aw-wizard>
   `
 })
 class WizardTestComponent {
@@ -62,13 +62,13 @@ describe('StrictNavigationMode', () => {
     wizardTestFixture.detectChanges();
 
     wizardTest = wizardTestFixture.componentInstance;
-    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    wizardState = wizardTestFixture.debugElement.query(By.css('aw-wizard')).injector.get(WizardState);
     navigationMode = wizardState.navigationMode;
   });
 
   it('should create', () => {
     expect(wizardTest).toBeTruthy();
-    expect(wizardTestFixture.debugElement.query(By.css('wizard'))).toBeTruthy();
+    expect(wizardTestFixture.debugElement.query(By.css('aw-wizard'))).toBeTruthy();
     expect(navigationMode instanceof StrictNavigationMode).toBe(true,
       'Navigation mode is not an instance of StrictNavigationMode');
   });

--- a/src/navigation/wizard-state.model.spec.ts
+++ b/src/navigation/wizard-state.model.spec.ts
@@ -6,13 +6,13 @@ import {ArchwizardModule} from '../archwizard.module';
 import {WizardState} from './wizard-state.model';
 
 @Component({
-  selector: 'test-wizard',
+  selector: 'aw-test-wizard',
   template: `
-    <wizard>
-      <wizard-step stepTitle='Steptitle 1'>Step 1</wizard-step>
-      <wizard-step stepTitle='Steptitle 2'>Step 2</wizard-step>
-      <wizard-step stepTitle='Steptitle 3'>Step 3</wizard-step>
-    </wizard>
+    <aw-wizard>
+      <aw-wizard-step stepTitle='Steptitle 1'>Step 1</aw-wizard-step>
+      <aw-wizard-step stepTitle='Steptitle 2'>Step 2</aw-wizard-step>
+      <aw-wizard-step stepTitle='Steptitle 3'>Step 3</aw-wizard-step>
+    </aw-wizard>
   `
 })
 class WizardTestComponent {
@@ -55,14 +55,14 @@ describe('WizardState', () => {
     wizardTestFixture.detectChanges();
 
     wizardTest = wizardTestFixture.componentInstance;
-    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    wizardState = wizardTestFixture.debugElement.query(By.css('aw-wizard')).injector.get(WizardState);
   });
 
   it('should create', () => {
     expect(wizardTest).toBeTruthy();
     expect(wizardState).toBeTruthy();
 
-    expect(wizardTestFixture.debugElement.query(By.css('wizard'))).toBeTruthy();
+    expect(wizardTestFixture.debugElement.query(By.css('aw-wizard'))).toBeTruthy();
   });
 
   it('should have steps', () => {

--- a/src/util/wizard-completion-step.interface.spec.ts
+++ b/src/util/wizard-completion-step.interface.spec.ts
@@ -10,14 +10,14 @@ import {WizardState} from '../navigation/wizard-state.model';
 import {NavigationMode} from '../navigation/navigation-mode.interface';
 
 @Component({
-  selector: 'test-wizard',
+  selector: 'aw-test-wizard',
   template: `
-    <wizard>
-      <wizard-step stepTitle='Steptitle 1' (stepEnter)="enterInto($event, 1)" (stepExit)="exitFrom($event, 1)">Step 1</wizard-step>
-      <wizard-step stepTitle='Steptitle 2' [canExit]="isValid"
-                   optionalStep (stepEnter)="enterInto($event, 2)" (stepExit)="exitFrom($event, 2)">Step 2</wizard-step>
-      <wizard-completion-step stepTitle='Completion steptitle 3' (stepEnter)="enterInto($event, 3)">Step 3</wizard-completion-step>
-    </wizard>
+    <aw-wizard>
+      <aw-wizard-step stepTitle='Steptitle 1' (stepEnter)="enterInto($event, 1)" (stepExit)="exitFrom($event, 1)">Step 1</aw-wizard-step>
+      <aw-wizard-step stepTitle='Steptitle 2' [canExit]="isValid"
+                   awOptionalStep (stepEnter)="enterInto($event, 2)" (stepExit)="exitFrom($event, 2)">Step 2</aw-wizard-step>
+      <aw-wizard-completion-step stepTitle='Completion steptitle 3' (stepEnter)="enterInto($event, 3)">Step 3</aw-wizard-completion-step>
+    </aw-wizard>
   `
 })
 class WizardTestComponent {
@@ -52,14 +52,14 @@ describe('WizardCompletionStep', () => {
     wizardTestFixture.detectChanges();
 
     wizardTest = wizardTestFixture.componentInstance;
-    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    wizardState = wizardTestFixture.debugElement.query(By.css('aw-wizard')).injector.get(WizardState);
     navigationMode = wizardState.navigationMode;
   });
 
   it('should create', () => {
     expect(wizardTest).toBeTruthy();
-    expect(wizardTestFixture.debugElement.queryAll(By.css('wizard-step')).length).toBe(2);
-    expect(wizardTestFixture.debugElement.queryAll(By.css('wizard-completion-step')).length).toBe(1);
+    expect(wizardTestFixture.debugElement.queryAll(By.css('aw-wizard-step')).length).toBe(2);
+    expect(wizardTestFixture.debugElement.queryAll(By.css('aw-wizard-completion-step')).length).toBe(1);
   });
 
   it('should set the wizard as completed after entering the completion step', fakeAsync(() => {

--- a/src/util/wizard-step.interface.spec.ts
+++ b/src/util/wizard-step.interface.spec.ts
@@ -13,20 +13,20 @@ import {Observable} from 'rxjs/Observable';
 import {_throw} from 'rxjs/observable/throw';
 
 @Component({
-  selector: 'test-wizard',
+  selector: 'aw-test-wizard',
   template: `
-    <wizard>
-      <wizard-step #firstStep stepTitle='Steptitle 1' (stepEnter)="enterInto($event, 1)" (stepExit)="exitFrom($event, 1)">
+    <aw-wizard>
+      <aw-wizard-step #firstStep stepTitle='Steptitle 1' (stepEnter)="enterInto($event, 1)" (stepExit)="exitFrom($event, 1)">
         Step 1
-      </wizard-step>
-      <wizard-step #secondStep stepTitle='Steptitle 2' [canExit]="canExit" [canEnter]="canEnter" optionalStep
+      </aw-wizard-step>
+      <aw-wizard-step #secondStep stepTitle='Steptitle 2' [canExit]="canExit" [canEnter]="canEnter" awOptionalStep
                    (stepEnter)="enterInto($event, 2)" (stepExit)="exitFrom($event, 2)">
         Step 2
-      </wizard-step>
-      <wizard-step #thirdStep stepTitle='Steptitle 3' (stepEnter)="enterInto($event, 3)" (stepExit)="exitFrom($event, 3)">
+      </aw-wizard-step>
+      <aw-wizard-step #thirdStep stepTitle='Steptitle 3' (stepEnter)="enterInto($event, 3)" (stepExit)="exitFrom($event, 3)">
         Step 3
-      </wizard-step>
-    </wizard>
+      </aw-wizard-step>
+    </aw-wizard>
   `
 })
 class WizardTestComponent {
@@ -73,7 +73,7 @@ describe('WizardStep', () => {
     wizardTestFixture.detectChanges();
 
     wizardTest = wizardTestFixture.componentInstance;
-    wizardState = wizardTestFixture.debugElement.query(By.css('wizard')).injector.get(WizardState);
+    wizardState = wizardTestFixture.debugElement.query(By.css('aw-wizard')).injector.get(WizardState);
     navigationMode = wizardState.navigationMode;
   });
 

--- a/tslint.json
+++ b/tslint.json
@@ -96,6 +96,8 @@
     "use-life-cycle-interface": true,
     "use-pipe-transform-interface": true,
     "component-class-suffix": true,
-    "directive-class-suffix": true
+    "directive-class-suffix": true,
+    "directive-selector": [true, "attribute", "aw", "camelCase"],
+    "component-selector": [true, "element", "aw", "kebab-case"]
   }
 }


### PR DESCRIPTION
This PR contains the following changes:
- added a tslint rule to ensure components and directives use an `aw` (archwizard) prefix
- added an `aw` prefix to all components and directives
- used an input alias for the `awGoToStep` directive
- renamed the `goToStep` input variable to `targetStep`