### PR TITLE
Make defaultStepIndex, disableNavigationBar and the navigation mode inputs updatable and allow the insertion/removal of wizard steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,29 @@ For additional information about how to write your own navigation bar please tak
 https://github.com/madoar/ng2-archwizard/blob/master/src/components/wizard-navigation-bar.component.horizontal.less and 
 https://github.com/madoar/ng2-archwizard/blob/master/src/components/wizard-navigation-bar.component.vertical.less.
 
+### Working with dynamically inserted and removed steps
+In some cases it may be required to remove or insert one or multiple steps after the wizard initialization, 
+for example after a user does some interaction with the wizard, it may be required to add or remove a later step.
+In such situations the wizard supports the removal and insertion of steps in the DOM.
+
+If you require to the dynamic removal or insertion of steps, please be aware that the angular component containing the wizard
+needs to trigger a `detectChanges()` call inside the `afterViewInit` lifecycle phase.
+This call can be triggered by adding the following lines to the component class:
+```typescript
+constructor(private _changeDetectionRef: ChangeDetectorRef) {}
+
+ngAfterViewInit(): void {
+  // Force another change detection in order to fix an occuring ExpressionChangedAfterItHasBeenCheckedError
+  this._changeDetectionRef.detectChanges();
+}
+```
+
+If an earlier step, compared to the current step, has been removed or inserted, 
+the wizard will adjust the index of the current step to make the changed state valid again.
+
+Please be also sure to not remove the step, the wizard is currently displaying, because otherwise the wizard will be inside an 
+invalid state, which may lead to strange and unexpected behavior.
+
 ## Example
 You can find an basic example project using `ng2-archwizard` [here](https://madoar.github.io/ng2-archwizard-demo). 
 The sources for the example can be found in the [ng2-archwizard-demo](https://github.com/madoar/ng2-archwizard-demo) repository.

--- a/src/components/wizard.component.spec.ts
+++ b/src/components/wizard.component.spec.ts
@@ -1,24 +1,43 @@
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {Component, ViewChild} from '@angular/core';
+import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {AfterViewInit, ChangeDetectorRef, Component, ViewChild} from '@angular/core';
 import {WizardComponent} from './wizard.component';
 import {By} from '@angular/platform-browser';
 import {ArchwizardModule} from '../archwizard.module';
 import {WizardState} from '../navigation/wizard-state.model';
 import {NavigationMode} from '../navigation/navigation-mode.interface';
+import {StrictNavigationMode} from '../navigation/strict-navigation-mode';
+import {FreeNavigationMode} from '../navigation/free-navigation-mode';
 
 @Component({
   selector: 'aw-test-wizard',
   template: `
-    <aw-wizard>
-      <aw-wizard-step stepTitle='Steptitle 1'>Step 1</aw-wizard-step>
+    <aw-wizard [navigationMode]="navigationMode" [disableNavigationBar]="disableNavigationBar" [defaultStepIndex]="defaultStepIndex">
+      <aw-wizard-step stepTitle='Steptitle 1' *ngIf="showStep1">Step 1</aw-wizard-step>
       <aw-wizard-step stepTitle='Steptitle 2'>Step 2</aw-wizard-step>
-      <aw-wizard-step stepTitle='Steptitle 3'>Step 3</aw-wizard-step>
+      <aw-wizard-step stepTitle='Steptitle 3' *ngIf="showStep3">Step 3</aw-wizard-step>
     </aw-wizard>
   `
 })
-class WizardTestComponent {
+class WizardTestComponent implements AfterViewInit {
+  public navigationMode = 'strict';
+
+  public disableNavigationBar = false;
+
+  public defaultStepIndex = 0;
+
+  public showStep1 = true;
+  public showStep3 = true;
+
   @ViewChild(WizardComponent)
   public wizard: WizardComponent;
+
+  constructor(private _changeDetectionRef: ChangeDetectorRef) {
+  }
+
+  ngAfterViewInit(): void {
+    // Force another change detection in order to fix an occuring ExpressionChangedAfterItHasBeenCheckedError
+    this._changeDetectionRef.detectChanges();
+  }
 }
 
 describe('WizardComponent', () => {
@@ -67,10 +86,12 @@ describe('WizardComponent', () => {
     expect(wizardTestFixture.debugElement.query(By.css('aw-wizard > :first-child')).name).toBe('aw-wizard-navigation-bar');
     expect(wizardTestFixture.debugElement.query(By.css('aw-wizard > :last-child')).name).toBe('div');
 
-    expect(navBar.classes).toEqual({ 'horizontal': true, 'vertical': false, 'small': true,
-      'large-filled': false, 'large-filled-symbols': false, 'large-empty': false, 'large-empty-symbols': false });
-    expect(wizard.classes).toEqual({ 'horizontal': true, 'vertical': false });
-    expect(wizardStepsDiv.classes).toEqual({ 'wizard-steps': true, 'horizontal': true, 'vertical': false });
+    expect(navBar.classes).toEqual({
+      'horizontal': true, 'vertical': false, 'small': true,
+      'large-filled': false, 'large-filled-symbols': false, 'large-empty': false, 'large-empty-symbols': false
+    });
+    expect(wizard.classes).toEqual({'horizontal': true, 'vertical': false});
+    expect(wizardStepsDiv.classes).toEqual({'wizard-steps': true, 'horizontal': true, 'vertical': false});
   });
 
   it('should contain navigation bar at the correct position in top navBarLocation mode', () => {
@@ -87,10 +108,12 @@ describe('WizardComponent', () => {
     expect(wizardTestFixture.debugElement.query(By.css('aw-wizard > :first-child')).name).toBe('aw-wizard-navigation-bar');
     expect(wizardTestFixture.debugElement.query(By.css('aw-wizard > :last-child')).name).toBe('div');
 
-    expect(navBar.classes).toEqual({ 'horizontal': true, 'vertical': false, 'small': true,
-      'large-filled': false, 'large-filled-symbols': false, 'large-empty': false, 'large-empty-symbols': false });
-    expect(wizard.classes).toEqual({ 'horizontal': true, 'vertical': false });
-    expect(wizardStepsDiv.classes).toEqual({ 'wizard-steps': true, 'horizontal': true, 'vertical': false });
+    expect(navBar.classes).toEqual({
+      'horizontal': true, 'vertical': false, 'small': true,
+      'large-filled': false, 'large-filled-symbols': false, 'large-empty': false, 'large-empty-symbols': false
+    });
+    expect(wizard.classes).toEqual({'horizontal': true, 'vertical': false});
+    expect(wizardStepsDiv.classes).toEqual({'wizard-steps': true, 'horizontal': true, 'vertical': false});
   });
 
   it('should contain navigation bar at the correct position in left navBarLocation mode', () => {
@@ -107,10 +130,12 @@ describe('WizardComponent', () => {
     expect(wizardTestFixture.debugElement.query(By.css('aw-wizard > :first-child')).name).toBe('aw-wizard-navigation-bar');
     expect(wizardTestFixture.debugElement.query(By.css('aw-wizard > :last-child')).name).toBe('div');
 
-    expect(navBar.classes).toEqual({ 'horizontal': false, 'vertical': true, 'small': true,
-      'large-filled': false, 'large-filled-symbols': false, 'large-empty': false, 'large-empty-symbols': false });
-    expect(wizard.classes).toEqual({ 'horizontal': false, 'vertical': true });
-    expect(wizardStepsDiv.classes).toEqual({ 'wizard-steps': true, 'horizontal': false, 'vertical': true });
+    expect(navBar.classes).toEqual({
+      'horizontal': false, 'vertical': true, 'small': true,
+      'large-filled': false, 'large-filled-symbols': false, 'large-empty': false, 'large-empty-symbols': false
+    });
+    expect(wizard.classes).toEqual({'horizontal': false, 'vertical': true});
+    expect(wizardStepsDiv.classes).toEqual({'wizard-steps': true, 'horizontal': false, 'vertical': true});
   });
 
   it('should contain navigation bar at the correct position in bottom navBarLocation mode', () => {
@@ -127,10 +152,12 @@ describe('WizardComponent', () => {
     expect(wizardTestFixture.debugElement.query(By.css('aw-wizard > :first-child')).name).toBe('div');
     expect(wizardTestFixture.debugElement.query(By.css('aw-wizard > :last-child')).name).toBe('aw-wizard-navigation-bar');
 
-    expect(navBar.classes).toEqual({ 'horizontal': true, 'vertical': false, 'small': true,
-      'large-filled': false, 'large-filled-symbols': false, 'large-empty': false, 'large-empty-symbols': false });
-    expect(wizard.classes).toEqual({ 'horizontal': true, 'vertical': false });
-    expect(wizardStepsDiv.classes).toEqual({ 'wizard-steps': true, 'horizontal': true, 'vertical': false });
+    expect(navBar.classes).toEqual({
+      'horizontal': true, 'vertical': false, 'small': true,
+      'large-filled': false, 'large-filled-symbols': false, 'large-empty': false, 'large-empty-symbols': false
+    });
+    expect(wizard.classes).toEqual({'horizontal': true, 'vertical': false});
+    expect(wizardStepsDiv.classes).toEqual({'wizard-steps': true, 'horizontal': true, 'vertical': false});
   });
 
   it('should contain navigation bar at the correct position in right navBarLocation mode', () => {
@@ -147,9 +174,103 @@ describe('WizardComponent', () => {
     expect(wizardTestFixture.debugElement.query(By.css('aw-wizard > :first-child')).name).toBe('div');
     expect(wizardTestFixture.debugElement.query(By.css('aw-wizard > :last-child')).name).toBe('aw-wizard-navigation-bar');
 
-    expect(navBar.classes).toEqual({ 'horizontal': false, 'vertical': true, 'small': true,
-      'large-filled': false, 'large-filled-symbols': false, 'large-empty': false, 'large-empty-symbols': false });
-    expect(wizard.classes).toEqual({ 'horizontal': false, 'vertical': true });
-    expect(wizardStepsDiv.classes).toEqual({ 'wizard-steps': true, 'horizontal': false, 'vertical': true });
+    expect(navBar.classes).toEqual({
+      'horizontal': false, 'vertical': true, 'small': true,
+      'large-filled': false, 'large-filled-symbols': false, 'large-empty': false, 'large-empty-symbols': false
+    });
+    expect(wizard.classes).toEqual({'horizontal': false, 'vertical': true});
+    expect(wizardStepsDiv.classes).toEqual({'wizard-steps': true, 'horizontal': false, 'vertical': true});
   });
+
+  it('should change the navigation mode correctly during runtime', () => {
+    expect(wizardTest.wizard.navigation instanceof StrictNavigationMode).toBe(true);
+
+    wizardTest.navigationMode = 'free';
+    wizardTestFixture.detectChanges();
+
+    expect(wizardTest.wizard.navigation instanceof FreeNavigationMode).toBe(true);
+  });
+
+  it('should change disableNavigationBar correctly during runtime', () => {
+    expect(wizardState.disableNavigationBar).toBe(false);
+
+    wizardTest.disableNavigationBar = true;
+    wizardTestFixture.detectChanges();
+
+    expect(wizardState.disableNavigationBar).toBe(true);
+  });
+
+  it('should change defaultStepIndex correctly during runtime', () => {
+    expect(wizardState.defaultStepIndex).toBe(0);
+
+    wizardTest.defaultStepIndex = 1;
+    wizardTestFixture.detectChanges();
+
+    expect(wizardState.defaultStepIndex).toBe(1);
+  });
+
+  it('should react on a previous step removal and insertion correctly', fakeAsync(() => {
+    navigationMode.goToStep(1);
+    tick();
+    wizardTestFixture.detectChanges();
+
+    expect(wizardState.currentStepIndex).toBe(1);
+    expect(wizardState.wizardSteps.length).toBe(3);
+
+    wizardTest.showStep1 = false;
+    wizardTestFixture.detectChanges();
+
+    expect(wizardState.currentStepIndex).toBe(0);
+    expect(wizardState.wizardSteps.length).toBe(2);
+
+    wizardTest.showStep1 = true;
+    wizardTestFixture.detectChanges();
+
+    expect(wizardState.currentStepIndex).toBe(1);
+    expect(wizardState.wizardSteps.length).toBe(3);
+  }));
+
+  it('should react on a later step removal and insertion correctly', fakeAsync(() => {
+    navigationMode.goToStep(1);
+    tick();
+    wizardTestFixture.detectChanges();
+
+    expect(wizardState.currentStepIndex).toBe(1);
+    expect(wizardState.wizardSteps.length).toBe(3);
+
+    wizardTest.showStep3 = false;
+    wizardTestFixture.detectChanges();
+
+    expect(wizardState.currentStepIndex).toBe(1);
+    expect(wizardState.wizardSteps.length).toBe(2);
+
+    wizardTest.showStep3 = true;
+    wizardTestFixture.detectChanges();
+
+    expect(wizardState.currentStepIndex).toBe(1);
+    expect(wizardState.wizardSteps.length).toBe(3);
+  }));
+
+  it('should react on a combined removal and insertion of previous and later steps correctly', fakeAsync(() => {
+    navigationMode.goToStep(1);
+    tick();
+    wizardTestFixture.detectChanges();
+
+    expect(wizardState.currentStepIndex).toBe(1);
+    expect(wizardState.wizardSteps.length).toBe(3);
+
+    wizardTest.showStep1 = false;
+    wizardTest.showStep3 = false;
+    wizardTestFixture.detectChanges();
+
+    expect(wizardState.currentStepIndex).toBe(0);
+    expect(wizardState.wizardSteps.length).toBe(1);
+
+    wizardTest.showStep1 = true;
+    wizardTest.showStep3 = true;
+    wizardTestFixture.detectChanges();
+
+    expect(wizardState.currentStepIndex).toBe(1);
+    expect(wizardState.wizardSteps.length).toBe(3);
+  }));
 });

--- a/src/navigation/wizard-state.model.ts
+++ b/src/navigation/wizard-state.model.ts
@@ -1,4 +1,4 @@
-import {Injectable, QueryList} from '@angular/core';
+import {Injectable} from '@angular/core';
 import {WizardStep} from '../util/wizard-step.interface';
 import {MovingDirection} from '../util/moving-direction.enum';
 import {NavigationMode} from './navigation-mode.interface';
@@ -17,11 +17,6 @@ import {navigationModeFactory} from './navigation-mode.provider';
 @Injectable()
 export class WizardState {
   /**
-   * The internal [[QueryList]] with all [[WizardStep]] objects belonging to the wizard model
-   */
-  private _wizardSteps: QueryList<WizardStep>;
-
-  /**
    * The initial step index, as taken from the [[WizardComponent]]
    */
   private _defaultStepIndex = 0;
@@ -29,14 +24,7 @@ export class WizardState {
   /**
    * An array representation of all wizard steps belonging to this model
    */
-  public get wizardSteps(): Array<WizardStep> {
-    /* istanbul ignore else */
-    if (this._wizardSteps) {
-      return this._wizardSteps.toArray();
-    } else {
-      return [];
-    }
-  }
+  public wizardSteps: Array<WizardStep> = [];
 
   /**
    * Sets the initial default step.
@@ -111,21 +99,26 @@ export class WizardState {
   }
 
   /**
-   * Initializes the wizard state with the given array of wizard steps.
-   * This process contains a reset of the wizard
+   * Updates the navigation mode to the navigation mode with the given name
    *
-   * @param wizardSteps The wizard steps
-   * @param navigationMode The name of the navigation mode to be set
-   * @param defaultStepIndex The default step index, to be used during the initialisation
-   * @param disableNavigationBar True, if the navigation bar should be disabled, i.e. not be used for navigating
+   * @param updatedNavigationMode The name of the new navigation mode
    */
-  initialize(wizardSteps: QueryList<WizardStep>, navigationMode: string, defaultStepIndex: number, disableNavigationBar: boolean): void {
-    this._wizardSteps = wizardSteps;
-    this._defaultStepIndex = defaultStepIndex;
-    this.disableNavigationBar = disableNavigationBar;
+  updateNavigationMode(updatedNavigationMode: string): void {
+    this.navigationMode = navigationModeFactory(updatedNavigationMode, this);
+  }
 
-    this.navigationMode = navigationModeFactory(navigationMode, this);
-    this.navigationMode.reset();
+  /**
+   * Updates the wizard steps to the new array
+   *
+   * @param updatedWizardSteps The updated wizard steps
+   */
+  updateWizardSteps(updatedWizardSteps: Array<WizardStep>): void {
+    // the wizard is currently not in the initialization phase
+    if (this.wizardSteps.length > 0 && this.currentStepIndex > -1) {
+      this.currentStepIndex = updatedWizardSteps.indexOf(this.wizardSteps[this.currentStepIndex]);
+    }
+
+    this.wizardSteps = updatedWizardSteps;
   }
 
   /**


### PR DESCRIPTION
This PR allows:
- the modification of the `defaultStepIndex`, `disableNavigationBar` and navigation mode inputs at runtime
- the insertion and removal of wizard steps after the wizard initialization (except the currently visible step)

Closes #31, #70, #75