### PR TITLE
Fix a bug with the reversal of the navigation bar direction

### DIFF
--- a/src/components/wizard-navigation-bar.component.ts
+++ b/src/components/wizard-navigation-bar.component.ts
@@ -53,7 +53,7 @@ export class WizardNavigationBarComponent {
   get wizardSteps(): Array<WizardStep> {
     switch (this.direction) {
       case 'right-to-left':
-        return this.wizardState.wizardSteps.reverse();
+        return this.wizardState.wizardSteps.slice().reverse();
       case 'left-to-right':
       default:
         return this.wizardState.wizardSteps;


### PR DESCRIPTION
The current version of `ng2-archwizard` has the bug, that the reversal of the wizard steps in the navigation bar through the usage of the navigation bar direction `right-to-left` leads to an in-place reversal of the wizard steps, instead of a reversal on a copy.

This PR fixes this.